### PR TITLE
Added support for non UTF-8 output encoding

### DIFF
--- a/Resources/config/intl.xml
+++ b/Resources/config/intl.xml
@@ -17,26 +17,20 @@
     <services>
         <service id="sonata.templating.helper.locale" class="%sonata.templating.helper.locale.class%">
             <tag name="templating.helper" alias="locale" />
+            <argument>%kernel.charset%</argument>
             <argument type="service" id="session" />
-            <call method="setCharset">
-                <argument>%kernel.charset%</argument>
-            </call>
         </service>
 
         <service id="sonata.templating.helper.number" class="%sonata.templating.helper.number.class%">
             <tag name="templating.helper" alias="number" />
+            <argument>%kernel.charset%</argument>
             <argument type="service" id="session" />
-            <call method="setCharset">
-                <argument>%kernel.charset%</argument>
-            </call>
         </service>
 
         <service id="sonata.templating.helper.datetime" class="%sonata.templating.helper.datetime.class%">
             <tag name="templating.helper" alias="datetime" />
+            <argument>%kernel.charset%</argument>
             <argument type="service" id="session" />
-            <call method="setCharset">
-                <argument>%kernel.charset%</argument>
-            </call>
         </service>
 
         <service id="sonata.twig.extension.locale" class="%sonata.twig.helper.locale.class%" public="false">

--- a/Templating/Helper/BaseHelper.php
+++ b/Templating/Helper/BaseHelper.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\IntlBundle\Templating\Helper;
 
+use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\Templating\Helper\Helper;
 
 /**
@@ -27,6 +28,21 @@ use Symfony\Component\Templating\Helper\Helper;
  */
 abstract class BaseHelper extends Helper
 {
+    protected $session;
+
+    /**
+     * Constructor.
+     *
+     * @param string $charset The output charset of the helper
+     * @param Session $session A Session instance
+     */
+    public function __construct($charset, Session $session)
+    {
+        $this->setCharset($charset);
+
+        $this->session = $session;
+    }
+
     /**
      * Fixes the charset by converting a string from an UTF-8 charset to the
      * charset of the kernel.

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -11,8 +11,6 @@
 
 namespace Sonata\IntlBundle\Templating\Helper;
 
-use Symfony\Component\HttpFoundation\Session;
-
 /**
  * DateHelper displays culture information. More information here
  * http://userguide.icu-project.org/formatparse/datetime
@@ -21,21 +19,6 @@ use Symfony\Component\HttpFoundation\Session;
  */
 class DateTimeHelper extends BaseHelper
 {
-    protected $session;
-
-
-    /**
-     * Constructor.
-     *
-     * @param Session $session A Session instance
-     * @param array $attributes The default attributes to apply to the NumberFormatter instance
-     * @param array $textAttributes The default text attributes to apply to the NumberFormatter instance
-     */
-    public function __construct(Session $session)
-    {
-        $this->session          = $session;
-    }
-
     public function formatDate($date, $locale = null)
     {
         $formatter = new \IntlDateFormatter(

--- a/Templating/Helper/LocaleHelper.php
+++ b/Templating/Helper/LocaleHelper.php
@@ -11,9 +11,8 @@
 
 namespace Sonata\IntlBundle\Templating\Helper;
 
-use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\Locale\Locale;
-    
+
 /**
  * LocaleHelper displays culture information.
  *
@@ -21,18 +20,6 @@ use Symfony\Component\Locale\Locale;
  */
 class LocaleHelper extends BaseHelper
 {
-    protected $session;
-
-    /**
-     * Constructor.
-     *
-     * @param HttpKernel $kernel A HttpKernel instance
-     */
-    public function __construct(Session $session)
-    {
-        $this->session = $session;
-    }
-
     public function country($code, $locale = null)
     {
 

--- a/Templating/Helper/NumberHelper.php
+++ b/Templating/Helper/NumberHelper.php
@@ -21,8 +21,6 @@ use Symfony\Component\Locale\Locale;
  */
 class NumberHelper extends BaseHelper
 {
-    protected $session;
-
     protected $attributes = array();
 
     protected $textAttributes = array();
@@ -30,13 +28,15 @@ class NumberHelper extends BaseHelper
     /**
      * Constructor.
      *
+     * @param string $charset The output charset of the helper
      * @param Session $session A Session instance
      * @param array $attributes The default attributes to apply to the NumberFormatter instance
      * @param array $textAttributes The default text attributes to apply to the NumberFormatter instance
      */
-    public function __construct(Session $session, array $attributes = array(), array $textAttributes = array())
+    public function __construct($charset, Session $session, array $attributes = array(), array $textAttributes = array())
     {
-        $this->session          = $session;
+        parent::__construct($charset, $session);
+
         $this->attributes       = $attributes;
         $this->textAttributes   = $textAttributes;
     }


### PR DESCRIPTION
The php Intl extension will always output UTF-8 encoded strings [1]. This
commit adds conversion from UTF-8 to the %kernel.charset% charset.

[1] http://www.php.net/manual/en/intl.examples.basic.php
