### PR TITLE
Accept 'fraction_digits' as argument option for \NumberFormatter::FRACTIO

### DIFF
--- a/Resources/doc/reference/number.rst
+++ b/Resources/doc/reference/number.rst
@@ -27,3 +27,4 @@ retrieved by using the session instance.
     {{ 42 | number_format_spellout }} => quarante-deux
     {{ 1.999 | number_format_percent }} => 200 %
     {{ 1 | number_format_ordinal }} => 1ᵉʳ
+    {{ -1.1337 | number_format_decimal({'fraction_digits': 2}, {'negative_prefix': 'MINUS'}) }} => MINUS1,34

--- a/Templating/Helper/NumberHelper.php
+++ b/Templating/Helper/NumberHelper.php
@@ -170,12 +170,22 @@ class NumberHelper extends BaseHelper
     {
         $formatter = new \NumberFormatter($culture, $style);
 
-        foreach($textAttributes + $this->textAttributes  as $name => $value) {
-            $formatter->setTextAttribute($name, $value);
+        foreach(array_merge($this->textAttributes, $textAttributes)  as $name => $value) {
+            $constantName = strtoupper($name);
+            if(!defined('NumberFormatter::'.$constantName)) {
+                throw new \InvalidArgumentException("Numberformatter has no text attribute '$name'");
+            }
+
+            $formatter->setTextAttribute(constant('NumberFormatter::'.$constantName), $value);
         }
 
-        foreach($attributes + $this->attributes as $name => $value) {
-            $formatter->setAttribute($name, $value);
+        foreach(array_merge($this->attributes, $attributes) as $name => $value) {
+            $constantName = strtoupper($name);
+            if(!defined('NumberFormatter::'.$constantName)) {
+                throw new \InvalidArgumentException("Numberformatter has no attribute '$name'");
+            }
+
+            $formatter->setAttribute(constant('NumberFormatter::'.$constantName), $value);
         }
 
         return $formatter;

--- a/Tests/Helper/NumberHelperTest.php
+++ b/Tests/Helper/NumberHelperTest.php
@@ -78,14 +78,31 @@ class NumberTest extends \PHPUnit_Framework_TestCase
             ->method('getLocale')
             ->will($this->returnValue('fr'));
 
-        $helper = new NumberHelper('UTF-8', $session, array(\NumberFormatter::FRACTION_DIGITS => 2), array(\NumberFormatter::NEGATIVE_PREFIX => 'MINUS'));
+        $helper = new NumberHelper('UTF-8', $session, array('fraction_digits' => 2), array('negative_prefix' => 'MINUS'));
 
         // Check that the 'default' options are used
         $this->assertEquals('1,34', $helper->formatDecimal(1.337));
         $this->assertEquals('MINUS1,34', $helper->formatDecimal(-1.337));
 
         // Check that the options are overwritten
-        $this->assertEquals('1,337', $helper->formatDecimal(1.337, array(\NumberFormatter::FRACTION_DIGITS => 3)));
-        $this->assertEquals('MIN1,34', $helper->formatDecimal(-1.337, array(), array(\NumberFormatter::NEGATIVE_PREFIX => 'MIN')));
+        $this->assertEquals('1,337', $helper->formatDecimal(1.337, array('fraction_digits' => 3)));
+        $this->assertEquals('MIN1,34', $helper->formatDecimal(-1.337, array(), array('negative_prefix' => 'MIN')));
+
+        // Check that exception are thrown on non-existing class constant
+        $exceptionThrown = false;
+        try {
+            $helper->formatDecimal(1.337, array('non_existant' => 3));
+        } catch(\InvalidArgumentException $e) {
+            $exceptionThrown = true;
+        }
+        $this->assertTrue($exceptionThrown);
+
+        $exceptionThrown = false;
+        try {
+            $helper->formatDecimal(1.337, array(), array('non_existant' => 'MIN'));
+        } catch(\InvalidArgumentException $e) {
+            $exceptionThrown = true;
+        }
+        $this->assertTrue($exceptionThrown);
     }
 }


### PR DESCRIPTION
Accept 'fraction_digits' as argument option for \NumberFormatter::FRACTION_DIGITS

The Twig templating engine does not allow the use of variables as keys of arrays. This implies that number_format\* filters could not receive NumberFormatter options in a nice matter.

This commit enables the use of string representations of the name of the class constants of NumberFormatter in the attributes arrays.
