### PR TITLE
Add compatibility to PHP 5.3.2 and PHP 5.3.3

### DIFF
--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -128,7 +128,8 @@ class DateTimeHelper extends BaseHelper
      */
     public function process(\IntlDateFormatter $formatter, \Datetime $date)
     {
-        return $this->fixCharset($formatter->format($date));
+        $time = $date->getTimestamp();
+        return $this->fixCharset($formatter->format($time));
     }
 
     /**


### PR DESCRIPTION
Add compatibility to PHP 5.3.2 and PHP 5.3.3 (Symfony2 requirements is ≥ PHP 5.3.2)

Support of DateTime object as parameter of IntlDateFormatter::format was added in PHP 5.3.4
