### PR TITLE
Fixed wrong argument

### DIFF
--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -128,7 +128,7 @@ class DateTimeHelper extends BaseHelper
      */
     public function process(\IntlDateFormatter $formatter, \Datetime $date)
     {
-        return $this->fixCharset($formatter->format($date));
+        return $this->fixCharset($formatter->format($date->getTimestamp()));
     }
 
     /**


### PR DESCRIPTION
Symfony\Component\Locale\Stub\StubIntlDateFormatter::format() requires unix timestamp
