### PR TITLE
Sync with latest symfony locale changes

### DIFF
--- a/Resources/config/intl.xml
+++ b/Resources/config/intl.xml
@@ -18,20 +18,20 @@
         <service id="sonata.templating.helper.locale" class="%sonata.templating.helper.locale.class%">
             <tag name="templating.helper" alias="locale" />
             <argument>%kernel.charset%</argument>
-            <argument type="service" id="session" />
+            <argument type="service" id="request" strict="false" />
         </service>
 
         <service id="sonata.templating.helper.number" class="%sonata.templating.helper.number.class%">
             <tag name="templating.helper" alias="number" />
             <argument>%kernel.charset%</argument>
-            <argument type="service" id="session" />
+            <argument type="service" id="request" strict="false" />
         </service>
 
         <service id="sonata.templating.helper.datetime" class="%sonata.templating.helper.datetime.class%">
             <tag name="templating.helper" alias="datetime" />
             <argument />
             <argument>%kernel.charset%</argument>
-            <argument type="service" id="session" />
+            <argument type="service" id="request" strict="false" />
         </service>
 
         <service id="sonata.twig.extension.locale" class="%sonata.twig.helper.locale.class%" public="false">

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -36,7 +36,7 @@ Configuration
 You can configure the default timezone used by the date helper with the following configuration. By default the
 ``php.ini`` value is used (retrieved by the ``date_default_timezone_get()`` function).
 
-The locale value used by the bundle is provided by the user session.
+The locale value used by the bundle is provided by the request.
 
 .. code-block:: yaml
 

--- a/Resources/doc/reference/locale.rst
+++ b/Resources/doc/reference/locale.rst
@@ -11,17 +11,17 @@ Twig usage
 ----------
 
 By default, if the second argument is not set then the current locale value is
-retrieved by using the session instance.
+retrieved by using the request instance.
 
 
 .. code-block:: twig
 
-    {{ 'FR' | country }} => France (if the current locale in session is 'fr')
+    {{ 'FR' | country }} => France (if the current locale in request is 'fr')
     {{ 'FR' | country('de') }} => Frankreich (force the locale)
 
-    {{ 'fr' | language }} => français (if the current locale in session is 'fr')
+    {{ 'fr' | language }} => français (if the current locale in request is 'fr')
     {{ 'fr' | language('en') }} => French (force the locale)
 
-    {{ 'fr' | locale }} => français (if the current locale in session is 'fr')
+    {{ 'fr' | locale }} => français (if the current locale in request is 'fr')
     {{ 'fr' | locale('en') }} => French (force the locale)
 

--- a/Resources/doc/reference/number.rst
+++ b/Resources/doc/reference/number.rst
@@ -15,7 +15,7 @@ Twig usage
 ----------
 
 By default, if the second argument is not set then the current locale value is
-retrieved by using the session instance.
+retrieved by using the request instance.
 
 
 .. code-block:: twig

--- a/Templating/Helper/BaseHelper.php
+++ b/Templating/Helper/BaseHelper.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\IntlBundle\Templating\Helper;
 
-use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Templating\Helper\Helper;
 
 /**
@@ -28,19 +28,19 @@ use Symfony\Component\Templating\Helper\Helper;
  */
 abstract class BaseHelper extends Helper
 {
-    protected $session;
+    protected $request;
 
     /**
      * Constructor.
      *
      * @param string $charset The output charset of the helper
-     * @param Session $session A Session instance
+     * @param Request $request A Request instance
      */
-    public function __construct($charset, Session $session)
+    public function __construct($charset, Request $request)
     {
         $this->setCharset($charset);
 
-        $this->session = $session;
+        $this->request = $request;
     }
 
     /**

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\IntlBundle\Templating\Helper;
 
-use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * DateHelper displays culture information. More information here
@@ -26,11 +26,11 @@ class DateTimeHelper extends BaseHelper
     /**
      * @param \DateTimeZone $defaultTimezone
      * @param $charset
-     * @param \Symfony\Component\HttpFoundation\Session $session
+     * @param \Symfony\Component\HttpFoundation\Request $request
      */
-    public function __construct(\DateTimeZone $defaultTimezone, $charset, Session $session)
+    public function __construct(\DateTimeZone $defaultTimezone, $charset, Request $request)
     {
-        parent::__construct($charset, $session);
+        parent::__construct($charset, $request);
 
         $this->defaultTimezone = $defaultTimezone;
     }
@@ -46,7 +46,7 @@ class DateTimeHelper extends BaseHelper
         $date = $this->getDatetime($date, $timezone);
 
         $formatter = new \IntlDateFormatter(
-            $locale ?: $this->session->getLocale() ,
+            $locale ?: $this->request->getLocale() ,
             \IntlDateFormatter::MEDIUM,
             \IntlDateFormatter::NONE,
             $timezone ?: $date->getTimezone()->getName(),
@@ -67,7 +67,7 @@ class DateTimeHelper extends BaseHelper
         $date = $this->getDatetime($datetime, $timezone);
 
         $formatter = new \IntlDateFormatter(
-            $locale ?: $this->session->getLocale() ,
+            $locale ?: $this->request->getLocale() ,
             \IntlDateFormatter::MEDIUM,
             \IntlDateFormatter::MEDIUM,
             $timezone ?: $date->getTimezone()->getName(),
@@ -88,7 +88,7 @@ class DateTimeHelper extends BaseHelper
         $date = $this->getDatetime($time, $timezone);
 
         $formatter = new \IntlDateFormatter(
-            $locale ?: $this->session->getLocale() ,
+            $locale ?: $this->request->getLocale() ,
             \IntlDateFormatter::NONE,
             \IntlDateFormatter::MEDIUM,
             $timezone ?: $date->getTimezone()->getName(),
@@ -110,7 +110,7 @@ class DateTimeHelper extends BaseHelper
         $date = $this->getDatetime($datetime, $timezone);
 
         $formatter = new \IntlDateFormatter(
-            $locale ?: $this->session->getLocale() ,
+            $locale ?: $this->request->getLocale() ,
             \IntlDateFormatter::FULL,
             \IntlDateFormatter::FULL,
             $timezone ?: $date->getTimezone()->getName(),

--- a/Templating/Helper/LocaleHelper.php
+++ b/Templating/Helper/LocaleHelper.php
@@ -27,7 +27,7 @@ class LocaleHelper extends BaseHelper
      */
     public function country($code, $locale = null)
     {
-        $countries = Locale::getDisplayCountries($locale ?: $this->session->getLocale());
+        $countries = Locale::getDisplayCountries($locale ?: $this->request->getLocale());
 
         if (array_key_exists($code, $countries)) {
             return $this->fixCharset($countries[$code]);
@@ -43,7 +43,7 @@ class LocaleHelper extends BaseHelper
      */
     public function language($code, $locale = null)
     {
-        $languages = Locale::getDisplayLanguages($locale ?: $this->session->getLocale());
+        $languages = Locale::getDisplayLanguages($locale ?: $this->request->getLocale());
 
         if (array_key_exists($code, $languages)) {
             return $this->fixCharset($languages[$code]);
@@ -59,7 +59,7 @@ class LocaleHelper extends BaseHelper
      */
     public function locale($code, $locale = null)
     {
-        $locales = Locale::getDisplayLocales($locale ?: $this->session->getLocale());
+        $locales = Locale::getDisplayLocales($locale ?: $this->request->getLocale());
 
         if (array_key_exists($code, $locales)) {
             return $this->fixCharset($locales[$code]);

--- a/Templating/Helper/NumberHelper.php
+++ b/Templating/Helper/NumberHelper.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\IntlBundle\Templating\Helper;
 
-use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Locale\Locale;
 
 /**
@@ -29,13 +29,13 @@ class NumberHelper extends BaseHelper
      * Constructor.
      *
      * @param string $charset The output charset of the helper
-     * @param \Symfony\Component\HttpFoundation\Session $session A Session instance
+     * @param \Symfony\Component\HttpFoundation\Request $request A Request instance
      * @param array $attributes The default attributes to apply to the NumberFormatter instance
      * @param array $textAttributes The default text attributes to apply to the NumberFormatter instance
      */
-    public function __construct($charset, Session $session, array $attributes = array(), array $textAttributes = array())
+    public function __construct($charset, Request $request, array $attributes = array(), array $textAttributes = array())
     {
-        parent::__construct($charset, $session);
+        parent::__construct($charset, $request);
 
         $this->attributes       = $attributes;
         $this->textAttributes   = $textAttributes;
@@ -109,7 +109,7 @@ class NumberHelper extends BaseHelper
      */
     public function formatCurrency($number, $currency, array $attributes = array(), array $textAttributes = array(), $locale = null)
     {
-        $formatter = $this->getFormatter($locale ?: $this->session->getLocale(), \NumberFormatter::CURRENCY, $attributes, $textAttributes);
+        $formatter = $this->getFormatter($locale ?: $this->request->getLocale(), \NumberFormatter::CURRENCY, $attributes, $textAttributes);
 
         return $this->fixCharset($formatter->formatCurrency($number, $currency));
     }
@@ -154,7 +154,7 @@ class NumberHelper extends BaseHelper
      */
     public function format($number, $style, array $attributes = array(), array $textAttributes = array(), $locale = null)
     {
-        $formatter = $this->getFormatter($locale ?: $this->session->getLocale(), $style, $attributes, $textAttributes);
+        $formatter = $this->getFormatter($locale ?: $this->request->getLocale(), $style, $attributes, $textAttributes);
 
         return $this->fixCharset($formatter->format($number));
     }

--- a/Tests/Helper/DateTimeHelperTest.php
+++ b/Tests/Helper/DateTimeHelperTest.php
@@ -19,13 +19,13 @@ class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
 {
     public function testLocale()
     {
-        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session', array('getLocale'), array(), 'Session', false);
+        $request = $this->getMock('Symfony\\Component\\HttpFoundation\\Request', array('getLocale'), array(), 'Request', false);
 
-        $session->expects($this->any())
+        $request->expects($this->any())
             ->method('getLocale')
             ->will($this->returnValue('fr'));
 
-        $helper = new DateTimeHelper(new \DateTimeZone('Europe/Paris'), 'UTF-8', $session);
+        $helper = new DateTimeHelper(new \DateTimeZone('Europe/Paris'), 'UTF-8', $request);
 
         $datetimeLondon = new \DateTime();
         $datetimeLondon->setDate(1981, 11, 30);

--- a/Tests/Helper/LocaleHelperTest.php
+++ b/Tests/Helper/LocaleHelperTest.php
@@ -20,13 +20,13 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 {
     public function testLocale()
     {
-        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session', array('getLocale'), array(), 'Session', false);
+        $request = $this->getMock('Symfony\\Component\\HttpFoundation\\Request', array('getLocale'), array(), 'Request', false);
 
-        $session->expects($this->any())
+        $request->expects($this->any())
             ->method('getLocale')
             ->will($this->returnValue('fr'));
 
-        $helper = new LocaleHelper('UTF-8', $session);
+        $helper = new LocaleHelper('UTF-8', $request);
 
         $this->assertEquals('français', $helper->language('fr'));
         $this->assertEquals('France', $helper->country('FR'));

--- a/Tests/Helper/NumberHelperTest.php
+++ b/Tests/Helper/NumberHelperTest.php
@@ -18,13 +18,13 @@ class NumberTest extends \PHPUnit_Framework_TestCase
 {
     public function testLocale()
     {
-        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session', array('getLocale'), array(), 'Session', false);
+        $request = $this->getMock('Symfony\\Component\\HttpFoundation\\Request', array('getLocale'), array(), 'Request', false);
 
-        $session->expects($this->any())
+        $request->expects($this->any())
             ->method('getLocale')
             ->will($this->returnValue('fr'));
 
-        $helper = new NumberHelper('UTF-8', $session);
+        $helper = new NumberHelper('UTF-8', $request);
 
         // currency
         $this->assertEquals('10,49 €', $helper->formatCurrency(10.49, 'EUR'));
@@ -72,13 +72,13 @@ class NumberTest extends \PHPUnit_Framework_TestCase
 
     public function testArguments()
     {
-        $session = $this->getMock('Symfony\\Component\\HttpFoundation\\Session', array('getLocale'), array(), 'Session', false);
+        $request = $this->getMock('Symfony\\Component\\HttpFoundation\\Request', array('getLocale'), array(), 'Request', false);
 
-        $session->expects($this->any())
+        $request->expects($this->any())
             ->method('getLocale')
             ->will($this->returnValue('fr'));
 
-        $helper = new NumberHelper('UTF-8', $session, array('fraction_digits' => 2), array('negative_prefix' => 'MINUS'));
+        $helper = new NumberHelper('UTF-8', $request, array('fraction_digits' => 2), array('negative_prefix' => 'MINUS'));
 
         // Check that the 'default' options are used
         $this->assertEquals('1,34', $helper->formatDecimal(1.337));


### PR DESCRIPTION
Sync with latest symfony changes where locale managment moved from Session class to Request class
