### PR TITLE
Enable date and time type overrinding.

### DIFF
--- a/Resources/doc/reference/datetime.rst
+++ b/Resources/doc/reference/datetime.rst
@@ -19,9 +19,9 @@ You can format a compatible date with 4 methods, a date can be:
 
 .. code-block:: jinja
 
-    {{ date_time_object | format_date }} => '1 août 2011'
+    {{ date_time_object | format_date }} => '1 févr. 2011'
     {{ date_time_object | format_time }} => '19:55:26'
-    {{ date_time_object | format_datetime }} => '1 août 2011 19:55:26'
+    {{ date_time_object | format_datetime }} => '1 févr. 2011 19:55:26'
 
 By default the helpers methods use the current user's locale to display 
 information. Of course this behavior can be controller from within the template 
@@ -30,13 +30,20 @@ by providing extra parameters :
 * pattern : the pattern to use to render the date
 * the locale
 * the timezone to use if date is not a ``DateTime`` instance
+* (``format_date`` and ``format_datetime`` only) the date type to use if no pattern
+  were provided: the given value must be one of ``\IntlDateFormatter::{SHORT, MEDIUM, LONG, FULL}``
+  or ``null`` (if ``null``, defaults to ``\IntlDateFormatter::MEDIUM``)
+* (``format_time`` and ``format_datetime`` only) the time type to use if no pattern
+  were provided: the given value must be one of ``\IntlDateFormatter::{SHORT, MEDIUM, LONG, FULL}``
+  or ``null`` (if ``null``, defaults to ``\IntlDateFormatter::MEDIUM``)
 
 .. code-block:: jinja
 
-    {{ date_time_object | format_date(null, 'fr', 'Europe/Paris') }} => '1 août 2011'
-    {{ date_time_object | format_time(null, 'fr', 'Europe/Paris') }} => '19:55:26'
-    {{ date_time_object | format_datetime(null, 'fr', 'Europe/Paris') }} => '1 août 2011 19:55:26'
-    {{ date_time_object | format_[date|time|datetime]('dd MMM Y G', 'fr', 'Europe/Paris') }} => '01 août 2011 ap. J.-C.'
+    {{ date_time_object | format_date(null, 'fr', 'Europe/Paris', constant('IntlDateFormatter::LONG')) }} => '1 février 2011'
+    {{ date_time_object | format_time(null, 'fr', 'Europe/Paris', constant('IntlDateFormatter::SHORT')) }} => '19:55'
+    {{ date_time_object | format_datetime(null, 'fr', 'Europe/Paris',
+        constant('IntlDateFormatter::LONG'), constant('IntlDateFormatter::SHORT')) }} => '1 février 2011 19:55'
+    {{ date_time_object | format_[date|time|datetime]('dd MMM Y G', 'fr', 'Europe/Paris') }} => '01 février 2011 ap. J.-C.'
 
 
 .. note::

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -41,15 +41,16 @@ class DateTimeHelper extends BaseHelper
      * @param \Datetime|string|integer $date
      * @param null|string $locale
      * @param null|string timezone
+     * @param null|integer dateType See \IntlDateFormatter::getDateType
      * @return string
      */
-    public function formatDate($date, $locale = null, $timezone = null)
+    public function formatDate($date, $locale = null, $timezone = null, $dateType = null)
     {
         $date = $this->getDatetime($date, $timezone);
 
         $formatter = new \IntlDateFormatter(
             $locale ?: $this->localeDetector->getLocale(),
-            \IntlDateFormatter::MEDIUM,
+            null === $dateType ? \IntlDateFormatter::MEDIUM : $dateType,
             \IntlDateFormatter::NONE,
             $timezone ?: $this->timezoneDetector->getTimezone(),
             \IntlDateFormatter::GREGORIAN
@@ -62,16 +63,18 @@ class DateTimeHelper extends BaseHelper
      * @param \Datetime|string|integer $datetime
      * @param null|string $locale
      * @param null|string timezone
+     * @param null|integer dateType See \IntlDateFormatter::getDateType
+     * @param null|integer timeType See \IntlDateFormatter::getTimeType
      * @return string
      */
-    public function formatDateTime($datetime, $locale = null, $timezone = null)
+    public function formatDateTime($datetime, $locale = null, $timezone = null, $dateType = null, $timeType = null)
     {
         $date = $this->getDatetime($datetime, $timezone);
 
         $formatter = new \IntlDateFormatter(
             $locale ?: $this->localeDetector->getLocale(),
-            \IntlDateFormatter::MEDIUM,
-            \IntlDateFormatter::MEDIUM,
+            null === $dateType ? \IntlDateFormatter::MEDIUM : $dateType,
+            null === $timeType ? \IntlDateFormatter::MEDIUM : $timeType,
             $timezone ?: $this->timezoneDetector->getTimezone(),
             \IntlDateFormatter::GREGORIAN
         );
@@ -83,16 +86,17 @@ class DateTimeHelper extends BaseHelper
      * @param \Datetime|string|integer $time
      * @param null|string $locale
      * @param null|string timezone
+     * @param null|integer timeType See \IntlDateFormatter::getTimeType
      * @return string
      */
-    public function formatTime($time, $locale = null, $timezone = null)
+    public function formatTime($time, $locale = null, $timezone = null, $timeType = null)
     {
         $date = $this->getDatetime($time, $timezone);
 
         $formatter = new \IntlDateFormatter(
             $locale ?: $this->localeDetector->getLocale(),
             \IntlDateFormatter::NONE,
-            \IntlDateFormatter::MEDIUM,
+            null === $timeType ? \IntlDateFormatter::MEDIUM : $timeType,
             $timezone ?: $this->timezoneDetector->getTimezone(),
             \IntlDateFormatter::GREGORIAN
         );

--- a/Tests/Helper/DateTimeHelperTest.php
+++ b/Tests/Helper/DateTimeHelperTest.php
@@ -67,6 +67,9 @@ class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('30 nov. 1981 02:00:00', $helper->formatDateTime($datetimeParis));
 
         // custom format
+        $this->assertEquals('30 novembre 1981', $helper->formatDate($datetimeParis, null, null, \IntlDateFormatter::LONG));
+        $this->assertEquals('02:00:00 HNEC', $helper->formatTime($datetimeParis, null, null, \IntlDateFormatter::LONG));
+        $this->assertEquals('30 novembre 1981 02:00', $helper->formatDateTime($datetimeParis, null, null, \IntlDateFormatter::LONG, \IntlDateFormatter::SHORT));
         $this->assertEquals('30 nov. 1981 ap. J.-C.', $helper->format($datetimeParis, 'dd MMM Y G'));
     }
 

--- a/Twig/Extension/DateTimeExtension.php
+++ b/Twig/Extension/DateTimeExtension.php
@@ -56,31 +56,31 @@ class DateTimeExtension extends \Twig_Extension
         );
     }
 
-    public function formatDate($date, $pattern = null, $locale = null, $timezone = null)
+    public function formatDate($date, $pattern = null, $locale = null, $timezone = null, $dateType = null)
     {
         if ($pattern) {
             return $this->helper->format($date, $pattern, $locale, $timezone);
         }
 
-        return $this->helper->formatDate($date, $locale, $timezone);
+        return $this->helper->formatDate($date, $locale, $timezone, $dateType);
     }
 
-    public function formatTime($time, $pattern = null, $locale = null, $timezone = null)
+    public function formatTime($time, $pattern = null, $locale = null, $timezone = null, $timeType = null)
     {
         if ($pattern) {
             return $this->helper->format($time, $pattern, $locale, $timezone);
         }
 
-        return $this->helper->formatTime($time, $locale, $timezone);
+        return $this->helper->formatTime($time, $locale, $timezone, $timeType);
     }
 
-    public function formatDatetime($time, $pattern = null, $locale = null, $timezone = null)
+    public function formatDatetime($time, $pattern = null, $locale = null, $timezone = null, $dateType = null, $timeType = null)
     {
         if ($pattern) {
             return $this->helper->format($time, $pattern, $locale, $timezone);
         }
 
-        return $this->helper->formatDateTime($time, $locale, $timezone);
+        return $this->helper->formatDateTime($time, $locale, $timezone, $dateType, $timeType);
     }
 
     /**


### PR DESCRIPTION
We often need to use a short date type in templates (for example `01/02/2011` instead of `1 févr. 2011` in french). This PR enable date and time type overriding (default is `IntlDateFormatter::MEDIUM` like before).

Unit tests OK.
Documentation updated.
