### PR TITLE
Don't access "request"-scope when it is not active.

### DIFF
--- a/Locale/RequestDetector.php
+++ b/Locale/RequestDetector.php
@@ -42,10 +42,11 @@ class RequestDetector implements LocaleDetectorInterface
      */
     public function getLocale()
     {
-        if ($request = $this->container->get('request', ContainerInterface::NULL_ON_INVALID_REFERENCE)) {
-            return $request->getLocale();
+        if ($this->container->isScopeActive("request")) {
+            if ($request = $this->container->get('request', ContainerInterface::NULL_ON_INVALID_REFERENCE)) {
+                return $request->getLocale();
+            }
         }
-
         return $this->defaultLocale;
     }
 }


### PR DESCRIPTION
While using the IntlBundle within Symfony console commands, I received errors saying that the "request"-scope can't be accessed. To avoid these errors I inserted an isScopeActive() call in RequestDetector->getLocale().
