### PR TITLE
[PR][2.1] Don't access "request"-scope when it is not active.

### DIFF
--- a/Locale/RequestDetector.php
+++ b/Locale/RequestDetector.php
@@ -47,6 +47,7 @@ class RequestDetector implements LocaleDetectorInterface
                 return $request->getLocale();
             }
         }
+
         return $this->defaultLocale;
     }
 }


### PR DESCRIPTION
I do a PR in relation with #46, about inactive scope request.

Can check that, merge and push a new stable 2.1 version ?

Many thanks.
