### PR TITLE
Modified Timezones validation to include linked tz

### DIFF
--- a/DependencyInjection/SonataIntlExtension.php
+++ b/DependencyInjection/SonataIntlExtension.php
@@ -102,9 +102,10 @@ class SonataIntlExtension extends Extension
      */
     private function validateTimezones(array $timezones)
     {
-        $availableTimezones = \DateTimeZone::listIdentifiers();
         foreach ($timezones as $timezone) {
-            if (!in_array($timezone, $availableTimezones)) {
+            try {
+                $tz = new \DateTimeZone($timezone);
+            } catch (\Exception $e) {
                 throw new \RuntimeException(sprintf('Unknown timezone "%s". Please check your sonata_intl configuration.', $timezone));
             }
         }


### PR DESCRIPTION
\DateTimeZone::listIdentifiers() does not return all valid time-zones. My timezone was modified as being a link to another timezone which should keep it working as is (confirmed with current iana TZ Coordinator). But this php function does not return it. Questions and bugs to this where filed and this modifications fixes this issue (Exceptions) that users with up to date tzdata and timezones like America/Montreal, Europe/Nicosia, Asia/Istanbul or Asia/Saigon would have.

(more info at https://answers.launchpad.net/ubuntu/+source/tzdata/+question/239234)
