### PR TITLE
Travis cache improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,16 @@ matrix:
     - env: SYMFONY_VERSION=2.8.*@dev
     - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_script:
   - composer selfupdate
+  - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
   - if [ "$SYMFONY_VERSION" = "2.8.*@dev" ] || [ "$SYMFONY_VERSION" = "3.0.x-dev as 2.8" ]; then SYMFONY_DEPRECATIONS_HELPER=strict; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-  - composer update --prefer-source --no-interaction $COMPOSER_FLAGS
+  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
   - sudo pip install -r Resources/doc/requirements.txt
 
 script: make test


### PR DESCRIPTION
@rande To get it working, please do the following:

* Create a private token for Travis under sonata-project organisation
* Add `GITHUB_OAUTH_TOKEN` on Travis project with the containing key. The env is set to secure as default.
* Run again Travis to get it working well.

If this approach looks good, This could be added on another sonata repositories. :+1: 

Please note: When you generate the key, **save the content elsewhere** in order to configure it on another Travis project. This will avoid to create a GitHub key for each project.