### PR TITLE
fix issue with some php internal classes which return null ...

### DIFF
--- a/Templating/Helper/BaseHelper.php
+++ b/Templating/Helper/BaseHelper.php
@@ -116,4 +116,25 @@ abstract class BaseHelper extends Helper
 
         return;
     }
+
+    /**
+     * https://wiki.php.net/rfc/internal_constructor_behaviour.
+     *
+     * @param mixed  $instance
+     * @param string $class
+     * @param array  $args
+     */
+    protected static function checkInternalClass($instance, $class, array $args = array())
+    {
+        if ($instance !== null) {
+            return;
+        }
+
+        $messages = array();
+        foreach ($args as $name => $value) {
+            $messages[] = sprintf('%s => %s', $name, $value);
+        }
+
+        throw new \RuntimeException(sprintf('Unable to create internal class: %s, with params: %s', $class, implode(', ', $messages)));
+    }
 }

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -26,6 +26,11 @@ class DateTimeHelper extends BaseHelper
     protected $timezoneDetector;
 
     /**
+     * @var \ReflectionClass
+     */
+    protected static $reflection;
+
+    /**
      * @param TimezoneDetectorInterface $timezoneDetector
      * @param string                    $charset
      * @param LocaleDetectorInterface   $localeDetector
@@ -35,6 +40,24 @@ class DateTimeHelper extends BaseHelper
         parent::__construct($charset, $localeDetector);
 
         $this->timezoneDetector = $timezoneDetector;
+    }
+
+    /**
+     * @param array $args
+     *
+     * @return \IntlDateFormatter
+     */
+    protected static function createInstance(array $args = array())
+    {
+        if (!self::$reflection) {
+            self::$reflection = new \ReflectionClass('IntlDateFormatter');
+        }
+
+        $instance = self::$reflection->newInstanceArgs($args);
+
+        self::checkInternalClass($instance, '\IntlDateFormatter', $args);
+
+        return $instance;
     }
 
     /**
@@ -49,13 +72,13 @@ class DateTimeHelper extends BaseHelper
     {
         $date = $this->getDatetime($date, $timezone);
 
-        $formatter = new \IntlDateFormatter(
-            $locale ?: $this->localeDetector->getLocale(),
-            null === $dateType ? \IntlDateFormatter::MEDIUM : $dateType,
-            \IntlDateFormatter::NONE,
-            $timezone ?: $this->timezoneDetector->getTimezone(),
-            \IntlDateFormatter::GREGORIAN
-        );
+        $formatter = self::createInstance(array(
+            'locale'   => $locale ?: $this->localeDetector->getLocale(),
+            'datetype' => null === $dateType ? \IntlDateFormatter::MEDIUM : $dateType,
+            'timetype' => \IntlDateFormatter::NONE,
+            'timezone' => $timezone ?: $this->timezoneDetector->getTimezone(),
+            'calendar' => \IntlDateFormatter::GREGORIAN,
+        ));
 
         return $this->process($formatter, $date);
     }
@@ -73,13 +96,13 @@ class DateTimeHelper extends BaseHelper
     {
         $date = $this->getDatetime($datetime, $timezone);
 
-        $formatter = new \IntlDateFormatter(
-            $locale ?: $this->localeDetector->getLocale(),
-            null === $dateType ? \IntlDateFormatter::MEDIUM : $dateType,
-            null === $timeType ? \IntlDateFormatter::MEDIUM : $timeType,
-            $timezone ?: $this->timezoneDetector->getTimezone(),
-            \IntlDateFormatter::GREGORIAN
-        );
+        $formatter = self::createInstance(array(
+            'locale'   => $locale ?: $this->localeDetector->getLocale(),
+            'datetype' => null === $dateType ? \IntlDateFormatter::MEDIUM : $dateType,
+            'timetype' => null === $timeType ? \IntlDateFormatter::MEDIUM : $timeType,
+            'timezone' => $timezone ?: $this->timezoneDetector->getTimezone(),
+            'calendar' => \IntlDateFormatter::GREGORIAN,
+        ));
 
         return $this->process($formatter, $date);
     }
@@ -96,13 +119,13 @@ class DateTimeHelper extends BaseHelper
     {
         $date = $this->getDatetime($time, $timezone);
 
-        $formatter = new \IntlDateFormatter(
-            $locale ?: $this->localeDetector->getLocale(),
-            \IntlDateFormatter::NONE,
-            null === $timeType ? \IntlDateFormatter::MEDIUM : $timeType,
-            $timezone ?: $this->timezoneDetector->getTimezone(),
-            \IntlDateFormatter::GREGORIAN
-        );
+        $formatter = self::createInstance(array(
+            'locale'   => $locale ?: $this->localeDetector->getLocale(),
+            'datetype' => \IntlDateFormatter::NONE,
+            'timetype' => null === $timeType ? \IntlDateFormatter::MEDIUM : $timeType,
+            'timezone' => $timezone ?: $this->timezoneDetector->getTimezone(),
+            'calendar' => \IntlDateFormatter::GREGORIAN,
+        ));
 
         return $this->process($formatter, $date);
     }
@@ -119,14 +142,14 @@ class DateTimeHelper extends BaseHelper
     {
         $date = $this->getDatetime($datetime, $timezone);
 
-        $formatter = new \IntlDateFormatter(
-            $locale ?: $this->localeDetector->getLocale(),
-            \IntlDateFormatter::FULL,
-            \IntlDateFormatter::FULL,
-            $timezone ?: $this->timezoneDetector->getTimezone(),
-            \IntlDateFormatter::GREGORIAN,
-            $pattern
-        );
+        $formatter = self::createInstance(array(
+            'locale'   => $locale ?: $this->localeDetector->getLocale(),
+            'datetype' => \IntlDateFormatter::FULL,
+            'timetype' => \IntlDateFormatter::FULL,
+            'timezone' => $timezone ?: $this->timezoneDetector->getTimezone(),
+            'calendar' => \IntlDateFormatter::GREGORIAN,
+            'pattern'  => $pattern,
+        ));
 
         return $this->process($formatter, $date);
     }

--- a/Templating/Helper/NumberHelper.php
+++ b/Templating/Helper/NumberHelper.php
@@ -178,6 +178,11 @@ class NumberHelper extends BaseHelper
     {
         $formatter = new \NumberFormatter($culture, $style);
 
+        self::checkInternalClass($formatter, '\NumberFormatter', array(
+            'culture' => $culture,
+            'style'   => $style,
+        ));
+
         foreach (array_merge($this->textAttributes, $textAttributes) as $name => $value) {
             $constantName = strtoupper($name);
             if (!defined('NumberFormatter::'.$constantName)) {

--- a/Tests/Helper/NumberHelperTest.php
+++ b/Tests/Helper/NumberHelperTest.php
@@ -111,4 +111,22 @@ class NumberHelperTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertTrue($exceptionThrown);
     }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testExceptionOnInvalidParams()
+    {
+        // https://wiki.php.net/rfc/internal_constructor_behaviour
+        $formatter = new \NumberFormatter('FR', -1);
+        $this->assertNull($formatter);
+
+        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector->expects($this->any())
+            ->method('getLocale')->will($this->returnValue('fr'));
+
+        $helper = new NumberHelper('UTF-8', $localeDetector, array('fraction_digits' => 2), array('negative_prefix' => 'MINUS'));
+
+        $helper->format(10.49, -1);
+    }
 }


### PR DESCRIPTION
 https://wiki.php.net/rfc/internal_constructor_behaviour : when their constructor is called with parameters that cannot be used to create a valid instance of the class, the constructor returns null. This is inconsistent with classes which are declared in userland which are not capable of returning null value, but instead have to indicate an error by throwing an exception.