### PR TITLE
Use Intl instead of deprecated Locale

### DIFF
--- a/Templating/Helper/LocaleHelper.php
+++ b/Templating/Helper/LocaleHelper.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\IntlBundle\Templating\Helper;
 
-use Symfony\Component\Locale\Locale;
+use Symfony\Component\Intl\Intl;
 
 /**
  * LocaleHelper displays culture information.
@@ -28,13 +28,9 @@ class LocaleHelper extends BaseHelper
      */
     public function country($code, $locale = null)
     {
-        $countries = Locale::getDisplayCountries($locale ?: $this->localeDetector->getLocale());
+        $name = Intl::getRegionBundle()->getCountryName($code, $locale ?: $this->localeDetector->getLocale());
 
-        if (array_key_exists($code, $countries)) {
-            return $this->fixCharset($countries[$code]);
-        }
-
-        return '';
+        return $name ? $this->fixCharset($name) : '';
     }
 
     /**
@@ -45,13 +41,11 @@ class LocaleHelper extends BaseHelper
      */
     public function language($code, $locale = null)
     {
-        $languages = Locale::getDisplayLanguages($locale ?: $this->localeDetector->getLocale());
+        $codes = explode('_', $code);
 
-        if (array_key_exists($code, $languages)) {
-            return $this->fixCharset($languages[$code]);
-        }
+        $name = Intl::getLanguageBundle()->getLanguageName($codes[0], isset($codes[1]) ? $code[1] : null, $locale ?: $this->localeDetector->getLocale());
 
-        return '';
+        return $name ? $this->fixCharset($name) : '';
     }
 
     /**
@@ -62,13 +56,9 @@ class LocaleHelper extends BaseHelper
      */
     public function locale($code, $locale = null)
     {
-        $locales = Locale::getDisplayLocales($locale ?: $this->localeDetector->getLocale());
+        $name = Intl::getLocaleBundle()->getLocaleName($code, $locale ?: $this->localeDetector->getLocale());
 
-        if (array_key_exists($code, $locales)) {
-            return $this->fixCharset($locales[$code]);
-        }
-
-        return '';
+        return $name ? $this->fixCharset($name) : '';
     }
 
     /**

--- a/Tests/Helper/LocaleHelperTest.php
+++ b/Tests/Helper/LocaleHelperTest.php
@@ -13,7 +13,6 @@
 namespace Sonata\IntlBundle\Tests\Helper;
 
 use Sonata\IntlBundle\Templating\Helper\LocaleHelper;
-use Symfony\Component\Locale\Locale;
 
 class LocaleHelperTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,6 +34,7 @@ class LocaleHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = $this->getHelper();
         $this->assertEquals('français', $helper->language('fr'));
+        $this->assertEquals('français', $helper->language('fr_FR'));
         $this->assertEquals('French', $helper->language('fr', 'en'));
         //        $this->assertEquals('', $helper->language('fr', 'fake'));
     }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/http-kernel": "~2.2",
         "symfony/dependency-injection": "~2.2",
         "symfony/templating": "~2.2",
-        "symfony/locale": "~2.2",
+        "symfony/intl": "^2.3.21",
         "twig/twig": "~1.12"
     },
     "require-dev": {


### PR DESCRIPTION
The Locale component is deprecated since Symfony 2.3 and will be remove from 3.0 which will be released next month. Symfony recommend to use the Intl component instead.