### PR TITLE
Use correct year parameter in examples

### DIFF
--- a/Resources/doc/reference/datetime.rst
+++ b/Resources/doc/reference/datetime.rst
@@ -45,7 +45,7 @@ by providing extra parameters :
     {{ date_time_object | format_time(null, 'fr', 'Europe/Paris', constant('IntlDateFormatter::SHORT')) }} => '19:55'
     {{ date_time_object | format_datetime(null, 'fr', 'Europe/Paris',
         constant('IntlDateFormatter::LONG'), constant('IntlDateFormatter::SHORT')) }} => '1 février 2011 19:55'
-    {{ date_time_object | format_[date|time|datetime]('dd MMM Y G', 'fr', 'Europe/Paris') }} => '01 février 2011 ap. J.-C.'
+    {{ date_time_object | format_[date|time|datetime]('dd MMM y G', 'fr', 'Europe/Paris') }} => '01 février 2011 ap. J.-C.'
 
 .. note::
 
@@ -75,7 +75,7 @@ When defining your Admin, you can also provide extra parameters, i.e. :
         {
             $listMapper
                 ->add('createdAt', 'date', array(
-                    'pattern' => 'dd MMM Y G',
+                    'pattern' => 'dd MMM y G',
                     'locale' => 'fr',
                     'timezone' => 'Europe/Paris',
                 ))


### PR DESCRIPTION
The year parameter in majuscule use the year of the begining of the week, not the real year for the date. So use the parameter in minuscule.

Example: the beginning of 2016 is in the middle of the week (friday). So for friday, saturday and sunday, the year showed by the "Y" is 2015. Wonderful isn't it?

```
`y`: Year
`Y`: Year (in "Week of Year" based calendars). This year designation is used in 
     ISO year-week calendar as defined by ISO 8601, but can be used in 
     non-Gregorian based calendar systems where week date processing is desired. 
     May not always be the same value as calendar year.
```

Ref :
http://framework.zend.com/manual/1.12/en/zend.date.constants.html#zend.date.constants.selfdefinedformats 
http://stackoverflow.com/questions/12423179/nsdateformatter-show-wrong-year