### PR TITLE
do not require acl package twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*
     - php: 5.5
-      env: SYMFONY_VERSION="3.0.*" ACL_VERSION="dev-master"
+      env: SYMFONY_VERSION="3.0.*"
     - php: 5.6
-      env: SYMFONY_VERSION="3.0.*" ACL_VERSION="dev-master"
+      env: SYMFONY_VERSION="3.0.*"
     - php: 7.0
-      env: SYMFONY_VERSION="3.0.*" ACL_VERSION="dev-master"
+      env: SYMFONY_VERSION="3.0.*"
 
   allow_failures:
     - php: hhvm
@@ -52,7 +52,6 @@ before_script:
   - composer global require phpunit/phpunit:@stable fabpot/php-cs-fixer --no-update
   - composer global update --prefer-dist --no-interaction
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-  - if [ "$ACL_VERSION" != "" ]; then composer require "symfony/security-acl:${ACL_VERSION}" --no-update; fi;
   - travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
   - export PATH=$HOME/.local/bin:$PATH
   - pip install -r Resources/doc/requirements.txt --user `whoami`


### PR DESCRIPTION
It is already required (dev), and should be removed when the admin
bundle gets a new stable version, which will require the package.