### PR TITLE
Add support for DateTimeImmutable

### DIFF
--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -18,6 +18,8 @@ use Sonata\IntlBundle\Timezone\TimezoneDetectorInterface;
  * DateHelper displays culture information. More information here
  * http://userguide.icu-project.org/formatparse/datetime.
  *
+ * NEXT_MAJOR: Remove all \DateTime hints as soon as PHP >=5.5 is required.
+ *
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  * @author Alexander <iam.asm89@gmail.com>
  */
@@ -46,10 +48,10 @@ class DateTimeHelper extends BaseHelper
     }
 
     /**
-     * @param \DateTimeInterface|string|int $date
-     * @param null|string                   $locale
-     * @param null|string                   $timezone
-     * @param null|int                      $dateType See \IntlDateFormatter::getDateType
+     * @param \DateTime|\DateTimeInterface|string|int $date
+     * @param null|string                             $locale
+     * @param null|string                             $timezone
+     * @param null|int                                $dateType See \IntlDateFormatter::getDateType
      *
      * @return string
      */
@@ -69,11 +71,11 @@ class DateTimeHelper extends BaseHelper
     }
 
     /**
-     * @param \DateTimeInterface|string|int $datetime
-     * @param null|string                   $locale
-     * @param null|string                   $timezone
-     * @param null|int                      $dateType See \IntlDateFormatter::getDateType
-     * @param null|int                      $timeType See \IntlDateFormatter::getTimeType
+     * @param \DateTime|\DateTimeInterface|string|int $datetime
+     * @param null|string                             $locale
+     * @param null|string                             $timezone
+     * @param null|int                                $dateType See \IntlDateFormatter::getDateType
+     * @param null|int                                $timeType See \IntlDateFormatter::getTimeType
      *
      * @return string
      */
@@ -93,10 +95,10 @@ class DateTimeHelper extends BaseHelper
     }
 
     /**
-     * @param \DateTimeInterface|string|int $time
-     * @param null|string                   $locale
-     * @param null|string                   $timezone
-     * @param null|int                      $timeType See \IntlDateFormatter::getTimeType
+     * @param \DateTime|\DateTimeInterface|string|int $time
+     * @param null|string                             $locale
+     * @param null|string                             $timezone
+     * @param null|int                                $timeType See \IntlDateFormatter::getTimeType
      *
      * @return string
      */
@@ -116,10 +118,10 @@ class DateTimeHelper extends BaseHelper
     }
 
     /**
-     * @param \DateTimeInterface|string|int $datetime
-     * @param                               $pattern
-     * @param null|string                   $locale
-     * @param null|string                   $timezone
+     * @param \DateTime|\DateTimeInterface|string|int $datetime
+     * @param                                         $pattern
+     * @param null|string                             $locale
+     * @param null|string                             $timezone
      *
      * @return string
      */
@@ -139,9 +141,9 @@ class DateTimeHelper extends BaseHelper
         return $this->process($formatter, $date);
     }
 
-    // NEXT_MAJOR: Change to \DateTimeInterface
-
     /**
+     * NEXT_MAJOR: Change to $date to \DateTimeInterface.
+     *
      * @param \IntlDateFormatter $formatter
      * @param \DateTime          $date
      *
@@ -157,8 +159,8 @@ class DateTimeHelper extends BaseHelper
     /**
      * Gets a date time instance by a given data and timezone.
      *
-     * @param \DateTimeInterface|string|int $data     Value representing date
-     * @param null|string                   $timezone Timezone of the date
+     * @param \DateTime|\DateTimeInterface|string|int $data     Value representing date
+     * @param null|string                             $timezone Timezone of the date
      *
      * @return \DateTime
      */

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -46,10 +46,10 @@ class DateTimeHelper extends BaseHelper
     }
 
     /**
-     * @param \Datetime|string|int $date
-     * @param null|string          $locale
-     * @param null|string          timezone
-     * @param null|int             dateType See \IntlDateFormatter::getDateType
+     * @param \DateTimeInterface|string|int $date
+     * @param null|string                   $locale
+     * @param null|string                   $timezone
+     * @param null|int                      $dateType See \IntlDateFormatter::getDateType
      *
      * @return string
      */
@@ -69,11 +69,11 @@ class DateTimeHelper extends BaseHelper
     }
 
     /**
-     * @param \Datetime|string|int $datetime
-     * @param null|string          $locale
-     * @param null|string          timezone
-     * @param null|int             dateType See \IntlDateFormatter::getDateType
-     * @param null|int             timeType See \IntlDateFormatter::getTimeType
+     * @param \DateTimeInterface|string|int $datetime
+     * @param null|string                   $locale
+     * @param null|string                   $timezone
+     * @param null|int                      $dateType See \IntlDateFormatter::getDateType
+     * @param null|int                      $timeType See \IntlDateFormatter::getTimeType
      *
      * @return string
      */
@@ -93,10 +93,10 @@ class DateTimeHelper extends BaseHelper
     }
 
     /**
-     * @param \Datetime|string|int $time
-     * @param null|string          $locale
-     * @param null|string          timezone
-     * @param null|int             timeType See \IntlDateFormatter::getTimeType
+     * @param \DateTimeInterface|string|int $time
+     * @param null|string                   $locale
+     * @param null|string                   $timezone
+     * @param null|int                      $timeType See \IntlDateFormatter::getTimeType
      *
      * @return string
      */
@@ -116,10 +116,10 @@ class DateTimeHelper extends BaseHelper
     }
 
     /**
-     * @param \Datetime|string|int $datetime
-     * @param                      $pattern
-     * @param null|string          $locale
-     * @param null|string          timezone
+     * @param \DateTimeInterface|string|int $datetime
+     * @param                               $pattern
+     * @param null|string                   $locale
+     * @param null|string                   $timezone
      *
      * @return string
      */
@@ -141,11 +141,11 @@ class DateTimeHelper extends BaseHelper
 
     /**
      * @param \IntlDateFormatter $formatter
-     * @param \Datetime          $date
+     * @param \DateTimeInterface $date
      *
      * @return string
      */
-    public function process(\IntlDateFormatter $formatter, \Datetime $date)
+    public function process(\IntlDateFormatter $formatter, \DateTimeInterface $date)
     {
         // strange bug with PHP 5.3.3-7+squeeze14 with Suhosin-Patch
         // getTimestamp() method alters the object...
@@ -155,10 +155,10 @@ class DateTimeHelper extends BaseHelper
     /**
      * Gets a date time instance by a given data and timezone.
      *
-     * @param \Datetime|string|int $data     Value representing date
-     * @param null|string          $timezone Timezone of the date
+     * @param \DateTimeInterface|string|int $data     Value representing date
+     * @param null|string                   $timezone Timezone of the date
      *
-     * @return \Datetime
+     * @return \DateTime
      */
     public function getDatetime($data, $timezone = null)
     {

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -139,13 +139,14 @@ class DateTimeHelper extends BaseHelper
         return $this->process($formatter, $date);
     }
 
+    // NEXT_MAJOR: Change to \DateTimeInterface
     /**
      * @param \IntlDateFormatter $formatter
-     * @param \DateTimeInterface $date
+     * @param \DateTime          $date
      *
      * @return string
      */
-    public function process(\IntlDateFormatter $formatter, \DateTimeInterface $date)
+    public function process(\IntlDateFormatter $formatter, \DateTime $date)
     {
         // strange bug with PHP 5.3.3-7+squeeze14 with Suhosin-Patch
         // getTimestamp() method alters the object...

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -140,6 +140,7 @@ class DateTimeHelper extends BaseHelper
     }
 
     // NEXT_MAJOR: Change to \DateTimeInterface
+
     /**
      * @param \IntlDateFormatter $formatter
      * @param \DateTime          $date

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -167,9 +167,7 @@ class DateTimeHelper extends BaseHelper
         }
 
         if ($data instanceof \DateTimeImmutable) {
-            $date = \DateTime::createFromFormat('U', $data->getTimestamp());
-
-            return $date;
+            return \DateTime::createFromFormat(\DateTime::ATOM, $data->format(\DateTime::ATOM));
         }
 
         // the format method accept array or integer

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -166,6 +166,12 @@ class DateTimeHelper extends BaseHelper
             return $data;
         }
 
+        if ($data instanceof \DateTimeImmutable) {
+            $date = \DateTime::createFromFormat('U', $data->getTimestamp());
+
+            return $date;
+        }
+
         // the format method accept array or integer
         if (is_numeric($data)) {
             $data = (int) $data;

--- a/Templating/Helper/DateTimeHelper.php
+++ b/Templating/Helper/DateTimeHelper.php
@@ -18,7 +18,7 @@ use Sonata\IntlBundle\Timezone\TimezoneDetectorInterface;
  * DateHelper displays culture information. More information here
  * http://userguide.icu-project.org/formatparse/datetime.
  *
- * NEXT_MAJOR: Remove all \DateTime hints as soon as PHP >=5.5 is required.
+ * NEXT_MAJOR: Remove all \DateTime hints from PHPDoc
  *
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  * @author Alexander <iam.asm89@gmail.com>

--- a/Tests/Helper/DateTimeHelperTest.php
+++ b/Tests/Helper/DateTimeHelperTest.php
@@ -118,12 +118,11 @@ class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('13:37', $helperWithMapping->format($dateParis, 'HH:mm'), 'A date in the Europe/Paris timezone, should be corrected when formatted with timezone Europe/Paris.');
     }
 
+    /**
+     * @requires PHP 5.5
+     */
     public function testImmutable()
     {
-        if (!class_exists('\DateTimeImmutable')) {
-            $this->markTestSkipped('\DateTimeImmutable is not available.');
-        }
-
         $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector->expects($this->any())
             ->method('getLocale')->will($this->returnValue('fr'));

--- a/Tests/Helper/DateTimeHelperTest.php
+++ b/Tests/Helper/DateTimeHelperTest.php
@@ -117,4 +117,25 @@ class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('12:37', $helper->format($dateParis, 'HH:mm'), 'A date in the Europe/Paris timezone, should be corrected when formatted with timezone Europe/London.');
         $this->assertEquals('13:37', $helperWithMapping->format($dateParis, 'HH:mm'), 'A date in the Europe/Paris timezone, should be corrected when formatted with timezone Europe/Paris.');
     }
+
+    public function testImmutable()
+    {
+        if (!class_exists('\DateTimeImmutable')) {
+            $this->markTestSkipped('\DateTimeImmutable is not available.');
+        }
+
+        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector->expects($this->any())
+            ->method('getLocale')->will($this->returnValue('fr'));
+
+        $timezoneDetector = $this->getMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
+        $timezoneDetector->expects($this->any())
+            ->method('getTimezone')->will($this->returnValue('Europe/Paris'));
+
+        $helper = new DateTimeHelper($timezoneDetector, 'UTF-8', $localeDetector);
+
+        $date = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s T', '2009-02-15 15:16:17 HKT');
+
+        $this->assertEquals('08:16', $helper->format($date, 'HH:mm'));
+    }
 }


### PR DESCRIPTION
Branch: 2.x (patch is BC)

## Changelog
```markdown
### Added
- Added support for `\DateTimeImmutable`.
```

## To do
 - [x] Decide whether timezone should be preserved.¹

¹ At the moment, `\DateTime` instances keep their timezone even if the argument `$timezone` of `getDatetime()` is set. As such the resulting timezone of this method is not consistent. That's why the current patch does not consider the argument for `\DateTimeImmutable` either (it does not even preserve it).

If we want to preserve the timezone, something like this might do it:
```php
$date = \DateTime::createFromFormat(\DateTime::ATOM, $data->format(\DateTime::ATOM));
```