### PR TITLE
Class as parameter

### DIFF
--- a/Resources/config/intl.xml
+++ b/Resources/config/intl.xml
@@ -2,6 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="sonata.intl.locale_detector.request.class">Sonata\IntlBundle\Locale\RequestDetector</parameter>
+        <parameter key="sonata.intl.locale_detector.request_stack.class">Sonata\IntlBundle\Locale\RequestStackDetector</parameter>
         <parameter key="sonata.intl.locale_detector.session.class">Sonata\IntlBundle\Locale\SessionDetector</parameter>
         <parameter key="sonata.intl.templating.helper.locale.class">Sonata\IntlBundle\Templating\Helper\LocaleHelper</parameter>
         <parameter key="sonata.intl.templating.helper.number.class">Sonata\IntlBundle\Templating\Helper\NumberHelper</parameter>
@@ -18,7 +19,7 @@
             <argument type="service" id="service_container" strict="false"/>
             <argument/>
         </service>
-        <service id="sonata.intl.locale_detector.request_stack" class="Sonata\IntlBundle\Locale\RequestStackDetector">
+        <service id="sonata.intl.locale_detector.request_stack" class="%sonata.intl.locale_detector.request_stack.class%">
             <argument type="service" id="request_stack"/>
             <argument/>
         </service>


### PR DESCRIPTION
## Changelog

Class for service `sonata.intl.locale_detector.request_stack` is now defined via parameters. This allow easier overiting
## Subject

Class for service RequestStackDetector defined via parameter
