### PR TITLE
Allow Twig 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/dependency-injection": "^2.2 || ^3.0",
         "symfony/templating": "^2.2 || ^3.0",
         "symfony/intl": "^2.3.21 || ^3.0",
-        "twig/twig": "^1.12"
+        "twig/twig": "^1.12 || ^2.0"
     },
     "require-dev": {
         "symfony/security": "^2.2 || ^3.0",


### PR DESCRIPTION
I am targetting this branch, because this is supposed to be BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Compatibility with Twig 2.0
```

## Subject

Twig 2.0 is out, let's allow it.