### PR TITLE
added captions to TOC tree in docs

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -3,10 +3,9 @@ Intl Bundle
 
 The ``SonataIntlBundle`` provides helper to the ``php-intl`` extension
 
-Reference Guide
----------------
-
 .. toctree::
+   :caption: Reference Guide
+   :name: reference-guide
    :maxdepth: 1
    :numbered:
 
@@ -16,10 +15,9 @@ Reference Guide
    reference/datetime
    reference/number
 
-Cookbook
---------
-
 .. toctree::
+  :caption: Cookbook
+  :name: cookbook
   :maxdepth: 1
   :numbered:
 


### PR DESCRIPTION
I am targeting this branch, because this is a docs change.

## Subject

Added captions to toc tree

This PR is based on the change of @dmarkowicz in https://github.com/sonata-project/SonataAdminBundle/pull/4387
