### PR TITLE
The strict parameter is deprecated since Symfony 2.8

### DIFF
--- a/DependencyInjection/Compiler/StrictPass.php
+++ b/DependencyInjection/Compiler/StrictPass.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\IntlBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class StrictPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('sonata.intl.locale_detector.request')) {
+            return;
+        }
+
+        $requestDetector = $container->getDefinition('sonata.intl.locale_detector.request');
+        $requestDetector->replaceArgument(0, $this->changeReference($requestDetector->getArgument(0), 'service_container'));
+
+        if (!$container->hasDefinition('sonata.intl.locale_detector.session')) {
+            return;
+        }
+
+        $sessionDetector = $container->getDefinition('sonata.intl.locale_detector.session');
+        $sessionDetector->replaceArgument(0, $this->changeReference($sessionDetector->getArgument(0), 'session'));
+    }
+
+    /**
+     * @param Reference $reference
+     * @param string    $serviceId
+     *
+     * @return Reference
+     */
+    private function changeReference(Reference $reference, $serviceId)
+    {
+        // Stay compatible with Symfony 2
+        if (method_exists($reference, 'isStrict')) {
+            return new Reference($serviceId, $reference->getInvalidBehavior(), $reference->isStrict(false));
+        }
+
+        return new Reference($serviceId, $reference->getInvalidBehavior());
+    }
+}

--- a/Resources/config/intl.xml
+++ b/Resources/config/intl.xml
@@ -15,7 +15,7 @@
     </parameters>
     <services>
         <service id="sonata.intl.locale_detector.request" class="%sonata.intl.locale_detector.request.class%">
-            <argument type="service" id="service_container" strict="false"/>
+            <argument type="service" id="service_container"/>
             <argument/>
         </service>
         <service id="sonata.intl.locale_detector.request_stack" class="Sonata\IntlBundle\Locale\RequestStackDetector">
@@ -23,7 +23,7 @@
             <argument/>
         </service>
         <service id="sonata.intl.locale_detector.session" class="%sonata.intl.locale_detector.session.class%">
-            <argument type="service" id="session" strict="false"/>
+            <argument type="service" id="session"/>
             <argument/>
         </service>
         <service id="sonata.intl.templating.helper.locale" class="%sonata.intl.templating.helper.locale.class%">

--- a/SonataIntlBundle.php
+++ b/SonataIntlBundle.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\IntlBundle;
 
+use Sonata\IntlBundle\DependencyInjection\Compiler\StrictPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SonataIntlBundle extends Bundle
@@ -29,5 +31,13 @@ class SonataIntlBundle extends Bundle
         return implode('.', array_slice(array_map(function ($val) {
             return (int) $val;
         }, explode('.', $version)), 0, 3));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new StrictPass());
     }
 }

--- a/Tests/DependencyInjection/Compiler/StrictPassTest.php
+++ b/Tests/DependencyInjection/Compiler/StrictPassTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\IntlBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\IntlBundle\DependencyInjection\Compiler\StrictPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class StrictPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!method_exists('Symfony\Component\DependencyInjection\Reference', 'isStrict')) {
+            $this->markTestSkipped('Requires Symfony 2.x');
+        }
+    }
+
+    public function testStrictParameter()
+    {
+        $requestDef = new Definition();
+        $requestDef->addArgument(new Reference('service_container', ContainerInterface::NULL_ON_INVALID_REFERENCE, false));
+
+        $this->setDefinition('sonata.intl.locale_detector.request', $requestDef);
+
+        $sessionDef = new Definition();
+        $sessionDef->addArgument(new Reference('session', ContainerInterface::NULL_ON_INVALID_REFERENCE, false));
+
+        $this->setDefinition('sonata.intl.locale_detector.session', $sessionDef);
+
+        $this->compile();
+
+        $this->assertFalse($requestDef->getArgument(0)->isStrict());
+        $this->assertFalse($sessionDef->getArgument(0)->isStrict());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new StrictPass());
+    }
+}


### PR DESCRIPTION
SonataIntlBundle throws two deprecation errors, see https://github.com/symfony/symfony/pull/20938

## Changelog

```markdown
### Removed
- The strict parameter is deprecated since Symfony 2.8 and was removed in 3.0.
```