### PR TITLE
Remove conflict on SonataUserBundle >= 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "sonata-project/user-bundle": "For user timezone detection"
     },
     "conflict": {
-        "sonata-project/user-bundle": "<2.0 || >=4.0"
+        "sonata-project/user-bundle": "<2.0 || >=5.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\IntlBundle\\": "" },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #158 https://github.com/sonata-project/SonataUserBundle/issues/880 https://github.com/sonata-project/SonataUserBundle/issues/879

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added compatiblity with SonataUserBundle 4
```

## Subject

<!-- Describe your Pull Request content here -->
It is not possible to install SonataUserBundle dev-master (4.x-dev) with this bundle at the same time, because of the conflict section of composer.json.

Let's see if the build passes with this change. It should not be a problem because it is only used here: 

https://github.com/sonata-project/SonataIntlBundle/blob/2.x/Tests/Timezone/UserBasedTimezoneDetectorTest.php