### PR TITLE
Remove getMock deprecations

### DIFF
--- a/Tests/Helper/DateTimeHelperTest.php
+++ b/Tests/Helper/DateTimeHelperTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\IntlBundle\Tests\Helper;
 
 use Sonata\IntlBundle\Templating\Helper\DateTimeHelper;
+use Sonata\IntlBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * Tests for the DateTimeHelper.
@@ -19,7 +20,7 @@ use Sonata\IntlBundle\Templating\Helper\DateTimeHelper;
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  * @author Alexander <iam.asm89@gmail.com>
  */
-class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
+class DateTimeHelperTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -28,11 +29,11 @@ class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testLocale()
     {
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector->expects($this->any())
             ->method('getLocale')->will($this->returnValue('fr'));
 
-        $timezoneDetector = $this->getMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
+        $timezoneDetector = $this->createMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
         $timezoneDetector->expects($this->any())
             ->method('getTimezone')->will($this->returnValue('Europe/Paris'));
 
@@ -81,15 +82,15 @@ class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testLocaleTimezones()
     {
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector->expects($this->any())
             ->method('getLocale')->will($this->returnValue('fr'));
 
-        $timezoneDetector = $this->getMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
+        $timezoneDetector = $this->createMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
         $timezoneDetector->expects($this->any())
             ->method('getTimezone')->will($this->returnValue('Europe/London'));
 
-        $timezoneDetectorWithMapping = $this->getMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
+        $timezoneDetectorWithMapping = $this->createMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
         $timezoneDetectorWithMapping->expects($this->any())
             ->method('getTimezone')->will($this->returnValue('Europe/Paris'));
 
@@ -123,11 +124,11 @@ class DateTimeHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testImmutable()
     {
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector->expects($this->any())
             ->method('getLocale')->will($this->returnValue('fr'));
 
-        $timezoneDetector = $this->getMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
+        $timezoneDetector = $this->createMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
         $timezoneDetector->expects($this->any())
             ->method('getTimezone')->will($this->returnValue('Europe/Paris'));
 

--- a/Tests/Helper/LocaleHelperTest.php
+++ b/Tests/Helper/LocaleHelperTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\IntlBundle\Tests\Helper;
 
 use Sonata\IntlBundle\Templating\Helper\LocaleHelper;
+use Sonata\IntlBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class LocaleHelperTest extends \PHPUnit_Framework_TestCase
+class LocaleHelperTest extends PHPUnit_Framework_TestCase
 {
     public function getHelper()
     {
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector->expects($this->any())
             ->method('getLocale')->will($this->returnValue('fr'));
 

--- a/Tests/Helper/NumberHelperTest.php
+++ b/Tests/Helper/NumberHelperTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\IntlBundle\Tests\Helper;
 
 use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Sonata\IntlBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class NumberHelperTest extends \PHPUnit_Framework_TestCase
+class NumberHelperTest extends PHPUnit_Framework_TestCase
 {
     public function testLocale()
     {
@@ -105,7 +106,7 @@ class NumberHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($formatter);
 
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector->expects($this->any())
             ->method('getLocale')->will($this->returnValue('fr'));
 
@@ -240,7 +241,7 @@ class NumberHelperTest extends \PHPUnit_Framework_TestCase
 
     private function createLocaleDetectorMock()
     {
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector
             ->expects($this->any())
             ->method('getLocale')->will($this->returnValue('fr'))

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\IntlBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4
+ *
+ * @author Oleksandr Savchenko <savchenko.oleksandr.ua@gmail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception, $message = '', $code = null)
+    {
+        if (is_callable('parent::expectException')) {
+            parent::expectException($exception);
+
+            if ($message !== '') {
+                parent::expectExceptionMessage($message);
+            }
+
+            if ($code !== null) {
+                parent::expectExceptionCode($code);
+            }
+        }
+
+        return parent::setExpectedException($exception, $message, $code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+    }
+}

--- a/Tests/Locale/RequestStackDetectorTest.php
+++ b/Tests/Locale/RequestStackDetectorTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\IntlBundle\Tests\Locale;
 
 use Sonata\IntlBundle\Locale\RequestStackDetector;
+use Sonata\IntlBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * Tests for the RequestStackDetector.
  *
  * @author Benjamin Lévêque <benjamin@leveque.me>
  */
-class RequestStackDetectorTest extends \PHPUnit_Framework_TestCase
+class RequestStackDetectorTest extends PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
@@ -29,8 +30,8 @@ class RequestStackDetectorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetLocale()
     {
-        $requestStack = $this->getMock('Symfony\Component\HttpFoundation\RequestStack');
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $requestStack = $this->createMock('Symfony\Component\HttpFoundation\RequestStack');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
 
         $requestStack
             ->expects($this->any())

--- a/Tests/Timezone/ChainTimezoneDetectorTest.php
+++ b/Tests/Timezone/ChainTimezoneDetectorTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\IntlBundle\Tests\Timezone;
 
+use Sonata\IntlBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\IntlBundle\Timezone\ChainTimezoneDetector;
 
 /**
@@ -18,7 +19,7 @@ use Sonata\IntlBundle\Timezone\ChainTimezoneDetector;
  *
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-class ChainTimezoneDetectorTest extends \PHPUnit_Framework_TestCase
+class ChainTimezoneDetectorTest extends PHPUnit_Framework_TestCase
 {
     public static function timezoneProvider()
     {
@@ -39,7 +40,7 @@ class ChainTimezoneDetectorTest extends \PHPUnit_Framework_TestCase
         $chainTimezoneDetector = new ChainTimezoneDetector('America/Denver');
 
         foreach ($detectorsTimezones as $timezone) {
-            $timezoneDetector = $this->getMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
+            $timezoneDetector = $this->createMock('Sonata\IntlBundle\Timezone\TimezoneDetectorInterface');
             $timezoneDetector
                 ->expects($this->any())
                 ->method('getTimezone')

--- a/Tests/Timezone/LocaleBasedTimezoneDetectorTest.php
+++ b/Tests/Timezone/LocaleBasedTimezoneDetectorTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\IntlBundle\Tests\Timezone;
 
+use Sonata\IntlBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\IntlBundle\Timezone\LocaleBasedTimezoneDetector;
 
 /**
@@ -18,11 +19,11 @@ use Sonata\IntlBundle\Timezone\LocaleBasedTimezoneDetector;
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class LocaleBasedTimezoneDetectorTest extends \PHPUnit_Framework_TestCase
+class LocaleBasedTimezoneDetectorTest extends PHPUnit_Framework_TestCase
 {
     public function testDetectsTimezoneForLocale()
     {
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector
             ->expects($this->any())
             ->method('getLocale')
@@ -35,7 +36,7 @@ class LocaleBasedTimezoneDetectorTest extends \PHPUnit_Framework_TestCase
 
     public function testTimezoneNotDetected()
     {
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector
             ->expects($this->any())
             ->method('getLocale')

--- a/Tests/Timezone/UserBasedTimezoneDetectorTest.php
+++ b/Tests/Timezone/UserBasedTimezoneDetectorTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\IntlBundle\Tests\Timezone;
 
+use Sonata\IntlBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\IntlBundle\Timezone\UserBasedTimezoneDetector;
 
 /**
@@ -18,7 +19,7 @@ use Sonata\IntlBundle\Timezone\UserBasedTimezoneDetector;
  *
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-class UserBasedTimezoneDetectorTest extends \PHPUnit_Framework_TestCase
+class UserBasedTimezoneDetectorTest extends PHPUnit_Framework_TestCase
 {
     /**
      * {@inheritdoc}
@@ -45,14 +46,14 @@ class UserBasedTimezoneDetectorTest extends \PHPUnit_Framework_TestCase
      */
     public function testDetectsTimezoneForUser($timezone)
     {
-        $user = $this->getMock('Sonata\UserBundle\Model\User');
+        $user = $this->createMock('Sonata\UserBundle\Model\User');
         $user
             ->expects($this->any())
             ->method('getTimezone')
             ->will($this->returnValue($timezone))
         ;
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token
             ->expects($this->any())
             ->method('getUser')
@@ -60,9 +61,9 @@ class UserBasedTimezoneDetectorTest extends \PHPUnit_Framework_TestCase
         ;
 
         if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            $storage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+            $storage = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         } else {
-            $storage = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+            $storage = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
         }
 
         $storage
@@ -78,9 +79,9 @@ class UserBasedTimezoneDetectorTest extends \PHPUnit_Framework_TestCase
     public function testTimezoneNotDetected()
     {
         if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            $storage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+            $storage = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         } else {
-            $storage = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+            $storage = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
         }
 
         $storage

--- a/Tests/Twig/Extension/NumberExtensionTest.php
+++ b/Tests/Twig/Extension/NumberExtensionTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\IntlBundle\Tests\Twig\Extension;
 
 use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Sonata\IntlBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\IntlBundle\Twig\Extension\NumberExtension;
 
 /**
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class NumberExtensionTest extends \PHPUnit_Framework_TestCase
+class NumberExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provideFormatArguments
@@ -178,7 +179,7 @@ class NumberExtensionTest extends \PHPUnit_Framework_TestCase
 
     private function createLocaleDetectorMock()
     {
-        $localeDetector = $this->getMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
+        $localeDetector = $this->createMock('Sonata\IntlBundle\Locale\LocaleDetectorInterface');
         $localeDetector
             ->expects($this->any())
             ->method('getLocale')->will($this->returnValue('fr'))


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change is pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Replaced getMock with createMock to not get deprecated messages on travis. Similar to the changes made on other SonataBundles