### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
-        "symfony/http-kernel": "^2.2 || ^3.0",
-        "symfony/dependency-injection": "^2.2 || ^3.0",
-        "symfony/templating": "^2.2 || ^3.0",
-        "symfony/intl": "^2.3.21 || ^3.0",
+        "php": "^7.1",
+        "symfony/http-kernel": "^2.8 || ^3.2",
+        "symfony/dependency-injection": "^2.8 || ^3.2",
+        "symfony/templating": "^2.8 || ^3.2",
+        "symfony/intl": "^2.8 || ^3.2",
         "twig/twig": "^1.12 || ^2.0"
     },
     "require-dev": {
-        "symfony/security": "^2.2 || ^3.0",
-        "symfony/security-acl": "^2.2 || ^3.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6 || ^1.0",
+        "symfony/security": "^2.8 || ^3.2",
+        "symfony/security-acl": "^2.8 || ^3.0",
+        "symfony/phpunit-bridge": "^3.3",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "suggest": {


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for old versions of php and Symfony
```
