### PR TITLE
Update all templates references to Twig namespaced syntax

### DIFF
--- a/src/Resources/views/CRUD/show_currency.html.twig
+++ b/src/Resources/views/CRUD/show_currency.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {%- if value is null -%}

--- a/src/Resources/views/CRUD/show_date.html.twig
+++ b/src/Resources/views/CRUD/show_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/show_datetime.html.twig
+++ b/src/Resources/views/CRUD/show_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {%- if value is empty -%}

--- a/src/Resources/views/CRUD/show_decimal.html.twig
+++ b/src/Resources/views/CRUD/show_decimal.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {%- if value is null -%}

--- a/src/Resources/views/CRUD/show_percent.html.twig
+++ b/src/Resources/views/CRUD/show_percent.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
     {%- if value is null -%}


### PR DESCRIPTION
I am targeting this branch, because it is patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- All templates references are updated to twig namespaced syntax
```

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See https://github.com/sonata-project/dev-kit/issues/380 for details