### PR TITLE
Update installation documentation for Symfony Flex

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -13,11 +13,26 @@ The easiest way to install ``SonataIntlBundle`` is to require it with Composer:
 
 .. code-block:: bash
 
-    $ php composer.phar require sonata-project/intl-bundle
+    composer require sonata-project/intl-bundle
 
 Alternatively, you could add a dependency into your ``composer.json`` file directly.
 
-Now, enable the bundle in the kernel:
+Now, enable the bundle in ``bundles.php`` file:
+
+.. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        Sonata\IntlBundle\SonataIntlBundle => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, you should enable bundles in your
+    ``AppKernel.php``.
 
 .. code-block:: php
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am updating documentation for Symfony Flex.

## Subject

Updating documentation to adopt new flex structure.