### PR TITLE
Minor composer improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
     "suggest": {
         "sonata-project/user-bundle": "For user timezone detection"
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
+        "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
+        "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
         "symfony/intl": "^2.8 || ^3.2 || ^4.0",
         "symfony/templating": "^2.8 || ^3.2 || ^4.0",
@@ -34,8 +36,9 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+        "sonata-project/user-bundle": "^3.6 || ^4.0",
         "symfony/phpunit-bridge": "^4.0",
-        "symfony/security": "^2.8 || ^3.2 || ^4.0",
+        "symfony/security-core": "^2.8 || ^3.2 || ^4.0",
         "symfony/security-acl": "^2.8 || ^3.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "sonata-project/user-bundle": "^3.6 || ^4.0",
         "symfony/phpunit-bridge": "^4.0",
-        "symfony/security-core": "^2.8 || ^3.2 || ^4.0",
-        "symfony/security-acl": "^2.8 || ^3.0"
+        "symfony/security-core": "^2.8 || ^3.2 || ^4.0"
     },
     "suggest": {
         "sonata-project/user-bundle": "For user timezone detection"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0",
+        "symfony/phpunit-bridge": "^4.0",
         "symfony/security": "^2.8 || ^3.2 || ^4.0",
         "symfony/security-acl": "^2.8 || ^3.0"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC

## Subject

<!-- Describe your Pull Request content here -->
- Added composer sort packages
- Declare missing symfony dependencies (replaced security by security-core)
- Add user-bundle to require-dev (used by one of the tests, and also is on the suggest)
- Removed security-acl as it is not used (it was added here: https://github.com/sonata-project/SonataIntlBundle/pull/106 . @core23 can you help with this one, do you remember why?)