### PR TITLE
Improved autowiring support for templating helpers

### DIFF
--- a/src/DependencyInjection/SonataIntlExtension.php
+++ b/src/DependencyInjection/SonataIntlExtension.php
@@ -36,6 +36,7 @@ class SonataIntlExtension extends Extension
         $config = $processor->processConfiguration($configuration, $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('autowire.xml');
         $loader->load('intl.xml');
 
         $this->configureTimezone($container, $config);

--- a/src/Resources/config/autowire.xml
+++ b/src/Resources/config/autowire.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\IntlBundle\Templating\Helper\DateTimeHelper" alias="sonata.intl.templating.helper.datetime"/>
+        <service id="Sonata\IntlBundle\Templating\Helper\LocaleHelper" alias="sonata.intl.templating.helper.locale"/>
+        <service id="Sonata\IntlBundle\Templating\Helper\NumberHelper" alias="sonata.intl.templating.helper.number"/>
+    </services>
+</container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

I am targeting this branch, because there should be a next 2.x release with this fix.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Improved autowiring support for templating helpers

```

## Subject

Trying to auto wire the templating helpers throws the following error:

> Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "sonata.intl.templating.helper.datetime" service to "Sonata\IntlBundle\Templating\Helper\DateTimeHelper" instead.

The solution is rather easy: add templating services based on their FQCN and alias them to the existing services to maintain backwards compatibility.