### PR TITLE
Fixed unit test

### DIFF
--- a/src/Templating/Helper/BaseHelper.php
+++ b/src/Templating/Helper/BaseHelper.php
@@ -80,7 +80,7 @@ abstract class BaseHelper extends Helper
 
         $info = explode("\n", $content);
 
-        if ('cli' == PHP_SAPI) {
+        if ('cli' == \PHP_SAPI) {
             foreach ($info as $line) {
                 $results = [];
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because one of the 2.x unit tests fails.

## Changelog
```markdown
### Fixed
- native constant invocation breaks test
```

## Subject

Due to a CS issue, one of the unit tests fails:

> 1) src/Templating/Helper/BaseHelper.php (native_constant_invocation)

The suggested solution is quite easy:

```php
-        if ('cli' == PHP_SAPI) {
+        if ('cli' == \PHP_SAPI) {
```
