### PR TITLE
Use "<time>" html tag when displaying fields of type date and datetime

### DIFF
--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -1,0 +1,23 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- spaceless %}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        {% set pattern = field_description.options.pattern|default(null) %}
+        {% set locale = field_description.options.locale|default(null) %}
+        {% set timezone = field_description.options.timezone|default(null) %}
+        {% set dateType = field_description.options.dateType|default(null) %}
+
+        <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">{{ value | format_date(pattern, locale, timezone, dateType) }}</time>
+    {%- endif -%}
+{% endspaceless -%}

--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -1,0 +1,24 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- spaceless %}
+    {%- if value is empty -%}
+        &nbsp;
+    {%- else -%}
+        {% set pattern = field_description.options.pattern|default(null) %}
+        {% set locale = field_description.options.locale|default(null) %}
+        {% set timezone = field_description.options.timezone|default(null) %}
+        {% set dateType = field_description.options.dateType|default(null) %}
+        {% set timeType = field_description.options.timeType|default(null) %}
+
+        <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">{{ value | format_datetime(pattern, locale, timezone, dateType, timeType) }}</time>
+    {%- endif -%}
+{% endspaceless -%}

--- a/src/Resources/views/CRUD/list_date.html.twig
+++ b/src/Resources/views/CRUD/list_date.html.twig
@@ -11,15 +11,6 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
-{% block field%}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {% set pattern = field_description.options.pattern|default(null) %}
-        {% set locale = field_description.options.locale|default(null) %}
-        {% set timezone = field_description.options.timezone|default(null) %}
-        {% set dateType = field_description.options.dateType|default(null) %}
-
-        {{ value | format_date(pattern, locale, timezone, dateType) }}
-    {%- endif -%}
+{% block field %}
+    {%- include '@SonataIntl/CRUD/display_date.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/list_datetime.html.twig
@@ -12,15 +12,5 @@ file that was distributed with this source code.
 {% extends admin.getTemplate('base_list_field') %}
 
 {% block field %}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {% set pattern = field_description.options.pattern|default(null) %}
-        {% set locale = field_description.options.locale|default(null) %}
-        {% set timezone = field_description.options.timezone|default(null) %}
-        {% set dateType = field_description.options.dateType|default(null) %}
-        {% set timeType = field_description.options.timeType|default(null) %}
-
-        {{ value | format_datetime(pattern, locale, timezone, dateType, timeType) }}
-    {%- endif -%}
+    {%- include '@SonataIntl/CRUD/display_datetime.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_date.html.twig
+++ b/src/Resources/views/CRUD/show_date.html.twig
@@ -11,15 +11,6 @@ file that was distributed with this source code.
 
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
-{% block field%}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {% set pattern = field_description.options.pattern|default(null) %}
-        {% set locale = field_description.options.locale|default(null) %}
-        {% set timezone = field_description.options.timezone|default(null) %}
-        {% set dateType = field_description.options.dateType|default(null) %}
-
-        {{ value | format_date(pattern, locale, timezone, dateType) }}
-    {%- endif -%}
+{% block field %}
+    {%- include '@SonataIntl/CRUD/display_date.html.twig' -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_datetime.html.twig
+++ b/src/Resources/views/CRUD/show_datetime.html.twig
@@ -12,15 +12,5 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {% set pattern = field_description.options.pattern|default(null) %}
-        {% set locale = field_description.options.locale|default(null) %}
-        {% set timezone = field_description.options.timezone|default(null) %}
-        {% set dateType = field_description.options.dateType|default(null) %}
-        {% set timeType = field_description.options.timeType|default(null) %}
-
-        {{ value | format_datetime(pattern, locale, timezone, dateType, timeType) }}
-    {%- endif -%}
+    {%- include '@SonataIntl/CRUD/display_datetime.html.twig' -%}
 {% endblock %}


### PR DESCRIPTION
## Subject

Use `<time>` html tag when displaying fields of type date and datetime. This allows to print the UTC dates using the "datetime" and "title" attributes.

I am targeting this branch, because these changes respect BC.

## Changelog

```markdown

### Changed
- Changed the rendering for date, datetime and time properties in order to use `<time>` tags, which print the dates in UTC using `datetime` and `title` attributes, allowing to view the UTC date with the default browser tooltip.
```

Example of UTC date 2017-04-06T00:11:38+00:00 printed with `America/Argentina/Buenos_Aires` (UTC -3) timezone:
```
<time datetime="2017-04-06T00:11:38+00:00" title="2017-04-06T00:11:38+00:00">
    05/04/2017 21:11:38
</time>
```
![datetime](https://user-images.githubusercontent.com/1231441/54076868-15805800-428f-11e9-9852-7087db8bc556.png)
