### PR TITLE
Twig deprecation notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
         "symfony/intl": "^2.8 || ^3.2 || ^4.0",
         "symfony/templating": "^2.8 || ^3.2 || ^4.0",
-        "twig/twig": "^1.12 || ^2.0"
+        "twig/twig": "^1.35 || ^2.4"
     },
     "conflict": {
         "sonata-project/user-bundle": "<2.0 || >=5.0"

--- a/src/Twig/Extension/DateTimeExtension.php
+++ b/src/Twig/Extension/DateTimeExtension.php
@@ -14,13 +14,15 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Twig\Extension;
 
 use Sonata\IntlBundle\Templating\Helper\DateTimeHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * DateTimeExtension extends Twig with localized date/time capabilities.
  *
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  */
-class DateTimeExtension extends \Twig_Extension
+class DateTimeExtension extends AbstractExtension
 {
     /**
      * @var DateTimeHelper
@@ -41,9 +43,9 @@ class DateTimeExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('format_date', [$this, 'formatDate'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('format_time', [$this, 'formatTime'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('format_datetime', [$this, 'formatDatetime'], ['is_safe' => ['html']]),
+            new TwigFunction('format_date', [$this, 'formatDate'], ['is_safe' => ['html']]),
+            new TwigFunction('format_time', [$this, 'formatTime'], ['is_safe' => ['html']]),
+            new TwigFunction('format_datetime', [$this, 'formatDatetime'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/Extension/LocaleExtension.php
+++ b/src/Twig/Extension/LocaleExtension.php
@@ -14,13 +14,15 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Twig\Extension;
 
 use Sonata\IntlBundle\Templating\Helper\LocaleHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
 /**
  * LocaleExtension extends Twig with local capabilities.
  *
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  */
-class LocaleExtension extends \Twig_Extension
+class LocaleExtension extends AbstractExtension
 {
     /**
      * @var LocaleHelper
@@ -41,9 +43,9 @@ class LocaleExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('country', [$this, 'country'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('locale', [$this, 'locale'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('language', [$this, 'language'], ['is_safe' => ['html']]),
+            new TwigFilter('country', [$this, 'country'], ['is_safe' => ['html']]),
+            new TwigFilter('locale', [$this, 'locale'], ['is_safe' => ['html']]),
+            new TwigFilter('language', [$this, 'language'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/Extension/NumberExtension.php
+++ b/src/Twig/Extension/NumberExtension.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Twig\Extension;
 
 use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
 /**
  * NumberExtension extends Twig with some filters to format numbers according
@@ -22,7 +24,7 @@ use Sonata\IntlBundle\Templating\Helper\NumberHelper;
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class NumberExtension extends \Twig_Extension
+class NumberExtension extends AbstractExtension
 {
     /**
      * @var NumberHelper The instance of the NumberHelper helper
@@ -43,13 +45,13 @@ class NumberExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('number_format_currency', [$this, 'formatCurrency'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('number_format_decimal', [$this, 'formatDecimal'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('number_format_scientific', [$this, 'formatScientific'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('number_format_spellout', [$this, 'formatSpellout'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('number_format_percent', [$this, 'formatPercent'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('number_format_duration', [$this, 'formatDuration'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('number_format_ordinal', [$this, 'formatOrdinal'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_currency', [$this, 'formatCurrency'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_decimal', [$this, 'formatDecimal'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_scientific', [$this, 'formatScientific'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_spellout', [$this, 'formatSpellout'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_percent', [$this, 'formatPercent'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_duration', [$this, 'formatDuration'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_ordinal', [$this, 'formatOrdinal'], ['is_safe' => ['html']]),
         ];
     }
 


### PR DESCRIPTION
## Subject
Fixing Twig deprecation notice in Symfony 4


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Update package `twig/twig` versions to `^1.35 || ^2.4`

### Fixed
* deprecation notice about using namespaced classes from `\Twig\`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
