### PR TITLE
Accept currency value represented as string (issue #256)

### DIFF
--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -154,8 +154,8 @@ class NumberHelper extends BaseHelper
     public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
     {
         // convert Doctrine's decimal type (fixed-point number represented as string) to float for backward compatibility
-        if (\is_string($number) && \is_numeric($number)) {
-            $number = \floatval($number);
+        if (\is_string($number) && is_numeric($number)) {
+            $number = (float) $number;
         }
 
         $methodArgs = array_pad(\func_get_args(), 6, null);

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -154,8 +154,8 @@ class NumberHelper extends BaseHelper
     public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
     {
         // convert Doctrine's decimal type (fixed-point number represented as string) to float for backward compatibility
-        if (is_string($number) && is_numeric($number)) {
-            $number = floatval($number);
+        if (\is_string($number) && \is_numeric($number)) {
+            $number = \floatval($number);
         }
 
         $methodArgs = array_pad(\func_get_args(), 6, null);

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -153,6 +153,11 @@ class NumberHelper extends BaseHelper
      */
     public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        // convert Doctrine's decimal type (fixed-point number represented as string) to float for backward compatibility
+        if (is_string($number) && is_numeric($number)) {
+            $number = floatval($number);
+        }
+
         $methodArgs = array_pad(\func_get_args(), 6, null);
 
         list($locale, $symbols) = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);

--- a/tests/Helper/NumberHelperTest.php
+++ b/tests/Helper/NumberHelperTest.php
@@ -32,6 +32,9 @@ class NumberHelperTest extends TestCase
         $this->assertSame('€10.50', $helper->formatCurrency(10.499, 'EUR'));
         $this->assertSame('€10,000.50', $helper->formatCurrency(10000.499, 'EUR'));
 
+        // test compatibility with Doctrine's decimal type (fixed-point number represented as string)
+        $this->assertSame('€10.49', $helper->formatCurrency('10.49', 'EUR'));
+
         $this->assertSame('€10.49', $helper->formatCurrency(10.49, 'EUR', [
             // the fraction_digits is not supported by the currency lib, https://bugs.php.net/bug.php?id=63140
             'fraction_digits' => 0,


### PR DESCRIPTION
## Subject
Make 2.6.0 backward compatible with 2.5.0 by accepting currency values represented as strings (e.g. Doctrine's decimal type).

Closes #256 

## Changelog
```markdown
### Fixed
- Restore backward compatibility by accepting currency values represented as string.
```