### PR TITLE
Bump "twig/twig" to "^2.9" in order to replace usages of `spaceless` tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
         "symfony/intl": "^2.8 || ^3.2 || ^4.0",
         "symfony/templating": "^2.8 || ^3.2 || ^4.0",
-        "twig/twig": "^1.35 || ^2.4"
+        "twig/twig": "^2.9"
     },
     "conflict": {
         "sonata-project/user-bundle": "<2.0 || >=5.0"

--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- spaceless %}
+{%- apply spaceless %}
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
@@ -20,4 +20,4 @@ file that was distributed with this source code.
 
         <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">{{ value | format_date(pattern, locale, timezone, dateType) }}</time>
     {%- endif -%}
-{% endspaceless -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- spaceless %}
+{%- apply spaceless %}
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
@@ -21,4 +21,4 @@ file that was distributed with this source code.
 
         <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">{{ value | format_datetime(pattern, locale, timezone, dateType, timeType) }}</time>
     {%- endif -%}
-{% endspaceless -%}
+{% endapply -%}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Bump "twig/twig" to "^2.9" in order to replace usages of deprecated features.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the changes are considered BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Bumped "twig/twig" dependency to "^2.9";
- Changed usages of `{% spaceless %}` tag, which is deprecated as of Twig 1.38 with `{% apply spaceless %}` filter;
```

Follow up of sonata-project/SonataAdminBundle#5576.