### PR TITLE
fix(extension): do not resolve the kernel.default_locale parameter

### DIFF
--- a/src/DependencyInjection/SonataIntlExtension.php
+++ b/src/DependencyInjection/SonataIntlExtension.php
@@ -96,7 +96,7 @@ class SonataIntlExtension extends Extension
 
     protected function configureLocale(ContainerBuilder $container, array $config)
     {
-        $container->getDefinition('sonata.intl.locale_detector.request_stack')->replaceArgument(1, $config['locale'] ?: $container->getParameter('kernel.default_locale'));
+        $container->getDefinition('sonata.intl.locale_detector.request_stack')->replaceArgument(1, $config['locale'] ?: '%kernel.default_locale%');
         $container->setAlias('sonata.intl.locale_detector', 'sonata.intl.locale_detector.request_stack');
     }
 


### PR DESCRIPTION
## Subject

Resolving this parameter in the extension imply it has to be defined before.
Therefore, it force a certain order on the loaded bundles (basically `FrameworkBundle` must be loaded before this bundle, since it is the one that defines this parameter).
We should not resolve parameter here but instead let them be resolved the latest possible.

I am targeting this branch, because it is a bug fix, backward compatible.

## Changelog

```markdown
### Changed
- Do not resolve the `kernel.default_locale` parameter when configuring the locale in the bundle extension.
```