### PR TITLE
Add `TimezoneAwareInterface`

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,5 +8,7 @@ jobs:
       - uses: actions/checkout@master
       - name: PHPStan
         uses: "docker://oskarstark/phpstan-ga"
+        env:
+          REQUIRE_DEV: true
         with:
           args: analyse

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,11 +1,40 @@
 UPGRADE 2.x
 ===========
 
+UPGRADE FROM 2.7 to 2.8
+=======================
+
+### Timezone detector
+
+``Sonata\IntlBundle\Timezone\TimezoneAwareInterface`` was added in order to provide
+timezone detection for any user class.
+
+Timezone inference based on the ``Sonata\UserBundle\Model\User::getTimezone()`` method
+is deprecated and will be dropped in 3.0 version.
+You MUST implement ``Sonata\IntlBundle\Timezone\TimezoneAwareInterface`` explicitly
+in your user class.
+
+Before:
+```php
+class User
+{
+    // ...
+}
+```
+
+After:
+```php
+class User implements \Sonata\IntlBundle\Timezone\TimezoneAwareInterface
+{
+    // ...
+}
+```
+
 UPGRADE FROM 2.3 to 2.4
 =======================
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,6 @@
         "symfony/phpunit-bridge": "^5.0",
         "symfony/security-core": "^4.4"
     },
-    "suggest": {
-        "sonata-project/user-bundle": "For user timezone detection"
-    },
     "config": {
         "sort-packages": true
     },

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -10,6 +10,17 @@ Timezone detectors
 User timezone detector
 ^^^^^^^^^^^^^^^^^^^^^^
 
+.. versionadded:: 2.7
+
+    If the model class for the authenticated user implements ``Sonata\IntlBundle\Timezone\TimezoneAwareInterface``,
+    it returns the timezone from its ``getTimezone()`` method.
+    For convenience, the ``Sonata\IntlBundle\Timezone\TimezoneAwareTrait`` is available,
+    which provides a basic implementation.
+
+**DEPRECATED**
+Relying on ``Sonata\UserBundle\Model\User`` is deprecated since 2.x in favor of
+explicit implementation of ``Sonata\IntlBundle\Timezone\TimezoneAwareInterface``.
+
 If the SonataUserBundle_ is enabled, it returns the timezone from the
 ``Sonata\UserBundle\Model\User::getTimezone()`` method.
 

--- a/src/DependencyInjection/SonataIntlExtension.php
+++ b/src/DependencyInjection/SonataIntlExtension.php
@@ -60,15 +60,12 @@ class SonataIntlExtension extends Extension
 
         $timezoneDetectors = $config['timezone']['detectors'];
 
-        $bundles = $container->getParameter('kernel.bundles');
-
-        if (0 === \count($timezoneDetectors)) { // no value define in the configuration, set one
-            // Support Sonata User Bundle.
-            if (isset($bundles['SonataUserBundle'])) {
-                $timezoneDetectors[] = 'sonata.intl.timezone_detector.user';
-            }
-
-            $timezoneDetectors[] = 'sonata.intl.timezone_detector.locale';
+        if (0 === \count($timezoneDetectors)) {
+            // define default values if there is no value defined in configuration.
+            $timezoneDetectors = [
+                'sonata.intl.timezone_detector.user',
+                'sonata.intl.timezone_detector.locale',
+            ];
         }
 
         foreach ($timezoneDetectors as $id) {
@@ -87,10 +84,6 @@ class SonataIntlExtension extends Extension
             ->replaceArgument(0, $config['timezone']['default'])
         ;
 
-        if (!isset($bundles['SonataUserBundle'])) {
-            $container->removeDefinition('sonata.intl.timezone_detector.user');
-        }
-
         $container->setParameter('sonata_intl.timezone.detectors', $timezoneDetectors);
     }
 
@@ -105,7 +98,7 @@ class SonataIntlExtension extends Extension
      *
      * @throws \RuntimeException If one of the locales is invalid
      */
-    private function validateTimezones(array $timezones)
+    private function validateTimezones(array $timezones): void
     {
         foreach ($timezones as $timezone) {
             try {

--- a/src/Timezone/TimezoneAwareInterface.php
+++ b/src/Timezone/TimezoneAwareInterface.php
@@ -14,16 +14,9 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Timezone;
 
 /**
- * Interfaces for services that are able to detect a timezone.
- *
- * @author Alexander <iam.asm89@gmail.com>
+ * @author Javier Spagnoletti <phansys@gmail.com>
  */
-interface TimezoneDetectorInterface
+interface TimezoneAwareInterface
 {
-    /**
-     * Get the appropriate timezone.
-     *
-     * @return string|null
-     */
-    public function getTimezone();
+    public function getTimezone(): ?string;
 }

--- a/src/Timezone/TimezoneAwareTrait.php
+++ b/src/Timezone/TimezoneAwareTrait.php
@@ -14,16 +14,19 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Timezone;
 
 /**
- * Interfaces for services that are able to detect a timezone.
+ * Basic Implementation of TimezoneAwareInterface.
  *
- * @author Alexander <iam.asm89@gmail.com>
+ * @author Javier Spagnoletti <phansys@gmail.com>
  */
-interface TimezoneDetectorInterface
+trait TimezoneAwareTrait
 {
     /**
-     * Get the appropriate timezone.
-     *
-     * @return string|null
+     * @var string|null
      */
-    public function getTimezone();
+    private $timezone;
+
+    final public function getTimezone(): ?string
+    {
+        return $this->timezone;
+    }
 }

--- a/src/Timezone/UserBasedTimezoneDetector.php
+++ b/src/Timezone/UserBasedTimezoneDetector.php
@@ -36,15 +36,29 @@ class UserBasedTimezoneDetector implements TimezoneDetectorInterface
     public function getTimezone()
     {
         if (!$token = $this->securityContext->getToken()) {
-            return;
+            return null;
         }
 
         if (!$user = $token->getUser()) {
-            return;
+            return null;
         }
 
-        if ($user instanceof User) {
+        if ($user instanceof TimezoneAwareInterface) {
             return $user->getTimezone();
         }
+
+        // NEXT_MAJOR: Remove this check and the related documentation at `docs/reference/configuration.rst`.
+        if ($user instanceof User) {
+            @trigger_error(sprintf(
+                'Timezone inference based on the "%s" class is deprecated since sonata-project/intl-bundle 2.x and will be dropped in 3.0 version.'
+                .' Implement "%s" explicitly in your user class instead.',
+                User::class,
+                TimezoneAwareInterface::class
+            ), E_USER_DEPRECATED);
+
+            return $user->getTimezone();
+        }
+
+        return null;
     }
 }

--- a/tests/Timezone/UserBasedTimezoneDetectorTest.php
+++ b/tests/Timezone/UserBasedTimezoneDetectorTest.php
@@ -14,25 +14,19 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Tests\Timezone;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\IntlBundle\Timezone\TimezoneAwareInterface;
+use Sonata\IntlBundle\Timezone\TimezoneAwareTrait;
 use Sonata\IntlBundle\Timezone\UserBasedTimezoneDetector;
 use Sonata\UserBundle\Model\User;
-use Sonata\UserBundle\SonataUserBundle;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
  */
-class UserBasedTimezoneDetectorTest extends TestCase
+final class UserBasedTimezoneDetectorTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (!class_exists(SonataUserBundle::class)) {
-            $this->markTestSkipped('SonataUserBundle must be installed to run this test.');
-        }
-    }
-
-    public static function timezoneProvider()
+    public static function timezoneProvider(): iterable
     {
         return [
             ['Europe/Paris'],
@@ -42,11 +36,53 @@ class UserBasedTimezoneDetectorTest extends TestCase
 
     /**
      * @dataProvider timezoneProvider
+     */
+    public function testUserTimezoneDetection(?string $timezone): void
+    {
+        $user = new class($timezone) implements TimezoneAwareInterface {
+            use TimezoneAwareTrait;
+
+            public function __construct(?string $timezone)
+            {
+                $this->timezone = $timezone;
+            }
+        };
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $storage = $this->createMock(TokenStorageInterface::class);
+
+        $storage
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($token)
+        ;
+
+        $timezoneDetector = new UserBasedTimezoneDetector($storage);
+        $this->assertSame($timezone, $timezoneDetector->getTimezone());
+    }
+
+    /**
+     * @dataProvider timezoneProvider
      *
      * @group legacy
+     *
+     * @expectedDeprecation Timezone inference based on the "Sonata\UserBundle\Model\User" class is deprecated since sonata-project/intl-bundle 2.x and will be dropped in 3.0 version. Implement "Sonata\IntlBundle\Timezone\TimezoneAwareInterface" explicitly in your user class instead.
      */
-    public function testDetectsTimezoneForUser($timezone)
+    public function testDetectsTimezoneForUser(?string $timezone): void
     {
+        if (!class_exists(User::class)) {
+            $this->markTestSkipped(sprintf(
+                '"%s" class must be available to run this test. You should install sonata-project/user-bundle.',
+                User::class
+            ));
+        }
+
         $user = $this->createMock(User::class);
         $user
             ->method('getTimezone')
@@ -70,7 +106,7 @@ class UserBasedTimezoneDetectorTest extends TestCase
         $this->assertSame($timezone, $timezoneDetector->getTimezone());
     }
 
-    public function testTimezoneNotDetected()
+    public function testTimezoneNotDetected(): void
     {
         $storage = $this->createMock(TokenStorageInterface::class);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add `TimezoneAwareInterface` in order to be implemented by classes used with `UserBasedTimezoneDetector`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to https://github.com/sonata-project/SonataAdminBundle/pull/5973#issuecomment-605483589.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `TimezoneAwareInterface` interface and `TimezoneAwareTrait` trait.

### Deprecated
- Deprecated timezone inference based on `Sonata\UserBundle\Model\User::getTimezone()`.

## Removed
- Removed dependency suggestion against "sonata-project/user-bundle".
```
    
## To do
    
- [x] Add tests.