### PR TITLE
Require "twig/intl-extra" in order to leverage `IntlExtension`

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -4,6 +4,22 @@ UPGRADE 2.x
 UPGRADE FROM 2.7 to 2.8
 =======================
 
+### Locale helper
+
+``Sonata\IntlBundle\Templating\Helper\LocaleHelper`` is marked as final, you must
+not inherit this class.
+
+``Sonata\IntlBundle\Templating\Helper\LocaleHelper::__construct()`` expects ``Twig\Extra\Intl\IntlExtension``
+in argument 3.
+
+### Number helper
+
+``Sonata\IntlBundle\Templating\Helper\NumberHelper`` is marked as final, you must
+not inherit this class.
+
+``Sonata\IntlBundle\Templating\Helper\LocaleHelper::__construct()`` expects ``Twig\Extra\Intl\IntlExtension``
+in argument 6.
+
 ### Timezone detector
 
 ``Sonata\IntlBundle\Timezone\TimezoneAwareInterface`` was added in order to provide

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,8 @@
         "symfony/http-kernel": "^4.4 || ^5.1",
         "symfony/intl": "^4.4 || ^5.1",
         "symfony/templating": "^4.4 || ^5.1",
+        "twig/extra-bundle": "^3.0",
+        "twig/intl-extra": "^3.0",
         "twig/twig": "^2.9 || ^3.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
         "symfony/phpunit-bridge": "^5.1",
         "symfony/security-core": "^4.4 || ^5.1"
     },
+    "suggest": {
+        "twig/extra-bundle": "Auto configures the Twig Intl extension"
+    },
     "config": {
         "sort-packages": true
     },

--- a/docs/reference/number.rst
+++ b/docs/reference/number.rst
@@ -35,7 +35,7 @@ For a list of available values, check the PHP_ documentation.
     {{ 42|number_format_spellout }} {# => quarante-deux #}
     {{ 1.999|number_format_percent }} {# => 200 % #}
     {{ 1|number_format_ordinal }} {# => 1ᵉʳ #}
-    {{ (-1.1337)|number_format_decimal({'fraction_digits': 2}, {'negative_prefix': 'MINUS'}) }} {# => MINUS1,34 #}
+    {{ (-1.1337)|number_format_decimal({'fraction_digit': 2}, {'negative_prefix': 'MINUS'}) }} {# => MINUS1,34 #}
 
 PHP usage
 ^^^^^^^^^
@@ -56,7 +56,7 @@ When defining your Admin, you can also provide extra parameters::
         {
             $listMapper
                 ->add('amount', 'decimal', [
-                    'attributes' => ['fraction_digits' => 2],
+                    'attributes' => ['fraction_digit' => 2],
                     'textAttributes' => ['negative_prefix' => 'MINUS'],
                 ])
             ;

--- a/src/Resources/config/intl.xml
+++ b/src/Resources/config/intl.xml
@@ -26,11 +26,16 @@
             <tag name="templating.helper" alias="locale"/>
             <argument>%kernel.charset%</argument>
             <argument type="service" id="sonata.intl.locale_detector"/>
+            <argument type="service" id="twig.extension.intl"/>
         </service>
         <service id="sonata.intl.templating.helper.number" class="%sonata.intl.templating.helper.number.class%" public="true">
             <tag name="templating.helper" alias="number"/>
             <argument>%kernel.charset%</argument>
             <argument type="service" id="sonata.intl.locale_detector"/>
+            <argument type="collection"/>
+            <argument type="collection"/>
+            <argument type="collection"/>
+            <argument type="service" id="twig.extension.intl"/>
         </service>
         <service id="sonata.intl.templating.helper.datetime" class="%sonata.intl.templating.helper.datetime.class%" public="true">
             <tag name="templating.helper" alias="datetime"/>

--- a/src/Resources/config/intl.xml
+++ b/src/Resources/config/intl.xml
@@ -26,7 +26,7 @@
             <tag name="templating.helper" alias="locale"/>
             <argument>%kernel.charset%</argument>
             <argument type="service" id="sonata.intl.locale_detector"/>
-            <argument type="service" id="twig.extension.intl"/>
+            <argument type="service" id="twig.extension.intl" on-invalid="null"/>
         </service>
         <service id="sonata.intl.templating.helper.number" class="%sonata.intl.templating.helper.number.class%" public="true">
             <tag name="templating.helper" alias="number"/>
@@ -35,7 +35,7 @@
             <argument type="collection"/>
             <argument type="collection"/>
             <argument type="collection"/>
-            <argument type="service" id="twig.extension.intl"/>
+            <argument type="service" id="twig.extension.intl" on-invalid="null"/>
         </service>
         <service id="sonata.intl.templating.helper.datetime" class="%sonata.intl.templating.helper.datetime.class%" public="true">
             <tag name="templating.helper" alias="datetime"/>

--- a/src/Templating/Helper/LocaleHelper.php
+++ b/src/Templating/Helper/LocaleHelper.php
@@ -45,11 +45,11 @@ class LocaleHelper extends BaseHelper
         // NEXT_MAJOR: Remove the ability to allow null values at argument 3 and remove the following lines in this method.
         if (null === $intlExtension) {
             @trigger_error(sprintf(
-                'Not passing an instance of "%s" as argument 3 for "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
-                .' and will throw an exception since version 3.x.',
+                'Not passing an instance of "%s" as argument 3 for "%s()" is deprecated since sonata-project/intl-bundle 2.x'
+                .' and will throw an exception in version 3.x.',
                 IntlExtension::class,
                 __METHOD__
-            ));
+            ), E_USER_DEPRECATED);
         }
     }
 

--- a/src/Templating/Helper/LocaleHelper.php
+++ b/src/Templating/Helper/LocaleHelper.php
@@ -41,6 +41,16 @@ class LocaleHelper extends BaseHelper
         parent::__construct($charset, $localeDetector);
 
         $this->intlExtension = $intlExtension;
+
+        // NEXT_MAJOR: Remove the ability to allow null values at argument 3 and remove the following lines in this method.
+        if (null === $intlExtension) {
+            @trigger_error(sprintf(
+                'Not passing an instance of "%s" as argument 3 for "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
+                .' and will throw an exception since version 3.x.',
+                IntlExtension::class,
+                __METHOD__
+            ));
+        }
     }
 
     /**
@@ -54,15 +64,6 @@ class LocaleHelper extends BaseHelper
         if ($this->intlExtension) {
             return $this->fixCharset($this->intlExtension->getCountryName($code, $locale ?: $this->localeDetector->getLocale()));
         }
-
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 3 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception since version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
 
         return $this->fixCharset(Countries::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }
@@ -79,15 +80,6 @@ class LocaleHelper extends BaseHelper
             $this->fixCharset($this->intlExtension->getLanguageName($code, $locale));
         }
 
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 3 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception since version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
-
         return $this->fixCharset(Languages::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }
 
@@ -102,15 +94,6 @@ class LocaleHelper extends BaseHelper
         if ($this->intlExtension) {
             $this->fixCharset($this->intlExtension->getLocaleName($code, $locale));
         }
-
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 3 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception since version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
 
         return $this->fixCharset(Locales::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }

--- a/src/Templating/Helper/LocaleHelper.php
+++ b/src/Templating/Helper/LocaleHelper.php
@@ -13,17 +13,36 @@ declare(strict_types=1);
 
 namespace Sonata\IntlBundle\Templating\Helper;
 
+use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Languages;
 use Symfony\Component\Intl\Locales;
+use Twig\Extra\Intl\IntlExtension;
 
 /**
  * LocaleHelper displays culture information.
+ *
+ * @final since sonata-project/intl-bundle 2.x
  *
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  */
 class LocaleHelper extends BaseHelper
 {
+    /**
+     * @var IntlExtension|null
+     */
+    private $intlExtension;
+
+    /**
+     * @param string $charset The output charset of the helper
+     */
+    public function __construct(string $charset, LocaleDetectorInterface $localeDetector, ?IntlExtension $intlExtension = null)
+    {
+        parent::__construct($charset, $localeDetector);
+
+        $this->intlExtension = $intlExtension;
+    }
+
     /**
      * @param string      $code
      * @param string|null $locale
@@ -32,6 +51,19 @@ class LocaleHelper extends BaseHelper
      */
     public function country($code, $locale = null)
     {
+        if ($this->intlExtension) {
+            return $this->fixCharset($this->intlExtension->getCountryName($code, $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 3 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception since version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         return $this->fixCharset(Countries::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }
 
@@ -43,6 +75,19 @@ class LocaleHelper extends BaseHelper
      */
     public function language($code, $locale = null)
     {
+        if ($this->intlExtension) {
+            $this->fixCharset($this->intlExtension->getLanguageName($code, $locale));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 3 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception since version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         return $this->fixCharset(Languages::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }
 
@@ -54,6 +99,19 @@ class LocaleHelper extends BaseHelper
      */
     public function locale($code, $locale = null)
     {
+        if ($this->intlExtension) {
+            $this->fixCharset($this->intlExtension->getLocaleName($code, $locale));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 3 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception since version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         return $this->fixCharset(Locales::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }
 

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -65,11 +65,11 @@ class NumberHelper extends BaseHelper
         // NEXT_MAJOR: Remove the ability to allow null values at argument 6 and remove the following lines in this method.
         if (null === $intlExtension) {
             @trigger_error(sprintf(
-                'Not passing an instance of "%s" as argument 6 for "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
+                'Not passing an instance of "%s" as argument 6 for "%s()" is deprecated since sonata-project/intl-bundle 2.x'
                 .' and will throw an exception in version 3.x.',
                 IntlExtension::class,
                 __METHOD__
-            ));
+            ), E_USER_DEPRECATED);
         }
     }
 

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -92,7 +92,7 @@ class NumberHelper extends BaseHelper
 
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
-            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::PERCENT, $textAttributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::PERCENT, $textAttributes, $symbols);
 
             return $this->fixCharset($intlExtension->formatNumberStyle('percent', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
@@ -119,7 +119,7 @@ class NumberHelper extends BaseHelper
 
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
-            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::DURATION, $textAttributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::DURATION, $textAttributes, $symbols);
 
             return $this->fixCharset($intlExtension->formatNumberStyle('duration', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
@@ -146,7 +146,7 @@ class NumberHelper extends BaseHelper
 
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
-            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::DECIMAL, $textAttributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::DECIMAL, $textAttributes, $symbols);
 
             return $this->fixCharset($intlExtension->formatNumberStyle('decimal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
@@ -173,7 +173,7 @@ class NumberHelper extends BaseHelper
 
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
-            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::SPELLOUT, $textAttributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::SPELLOUT, $textAttributes, $symbols);
 
             return $this->fixCharset($intlExtension->formatNumberStyle('spellout', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
@@ -199,16 +199,16 @@ class NumberHelper extends BaseHelper
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
 
-        if ($this->intlExtension) {
-            $attributes = self::processLegacyAttributes($attributes);
-            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::CURRENCY, $textAttributes);
-
-            return $this->fixCharset($intlExtension->formatCurrency($number, $currency, $attributes, $locale ?: $this->localeDetector->getLocale()));
-        }
-
         // convert Doctrine's decimal type (fixed-point number represented as string) to float for backward compatibility
         if (\is_string($number) && is_numeric($number)) {
             $number = (float) $number;
+        }
+
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::CURRENCY, $textAttributes, $symbols);
+
+            return $this->fixCharset($intlExtension->formatCurrency($number, $currency, $attributes, $locale ?: $this->localeDetector->getLocale()));
         }
 
         $formatter = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), \NumberFormatter::CURRENCY, $attributes, $textAttributes, $symbols);
@@ -235,7 +235,7 @@ class NumberHelper extends BaseHelper
 
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
-            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::SCIENTIFIC, $textAttributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::SCIENTIFIC, $textAttributes, $symbols);
 
             return $this->fixCharset($intlExtension->formatNumberStyle('scientific', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
@@ -262,7 +262,7 @@ class NumberHelper extends BaseHelper
 
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
-            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::ORDINAL, $textAttributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::ORDINAL, $textAttributes, $symbols);
 
             return $this->fixCharset($intlExtension->formatNumberStyle('ordinal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
@@ -290,7 +290,7 @@ class NumberHelper extends BaseHelper
 
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
-            $intlExtension = $this->getIntlExtension($locale, $style, $textAttributes);
+            $intlExtension = $this->getIntlExtension($locale, $style, $textAttributes, $symbols);
 
             return $this->fixCharset($intlExtension->formatNumberStyle($style, $number, $attributes, $locale ?: $this->localeDetector->getLocale()));
         }
@@ -466,13 +466,13 @@ class NumberHelper extends BaseHelper
         return $attributes;
     }
 
-    private function getIntlExtension(?string $locale = null, int $style, array $textAttributes): IntlExtension
+    private function getIntlExtension(?string $locale = null, int $style, array $textAttributes = [], array $symbols = []): IntlExtension
     {
-        if (empty($textAttributes)) {
+        if (empty($textAttributes) && empty($symbols)) {
             return $this->intlExtension;
         }
 
-        $numberFormatterProto = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), $style, [], $textAttributes);
+        $numberFormatterProto = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), $style, [], $textAttributes, $symbols);
 
         return new IntlExtension(null, $numberFormatterProto);
     }

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -61,6 +61,16 @@ class NumberHelper extends BaseHelper
         $this->textAttributes = $textAttributes;
         $this->symbols = $symbols;
         $this->intlExtension = $intlExtension;
+
+        // NEXT_MAJOR: Remove the ability to allow null values at argument 6 and remove the following lines in this method.
+        if (null === $intlExtension) {
+            @trigger_error(sprintf(
+                'Not passing an instance of "%s" as argument 6 for "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
+                .' and will throw an exception in version 3.x.',
+                IntlExtension::class,
+                __METHOD__
+            ));
+        }
     }
 
     /**
@@ -86,15 +96,6 @@ class NumberHelper extends BaseHelper
 
             return $this->fixCharset($intlExtension->formatNumberStyle('percent', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
-
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception in version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
 
         return $this->format($number, \NumberFormatter::PERCENT, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -123,15 +124,6 @@ class NumberHelper extends BaseHelper
             return $this->fixCharset($intlExtension->formatNumberStyle('duration', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception in version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
-
         return $this->format($number, \NumberFormatter::DURATION, $attributes, $textAttributes, $symbols, $locale);
     }
 
@@ -158,15 +150,6 @@ class NumberHelper extends BaseHelper
 
             return $this->fixCharset($intlExtension->formatNumberStyle('decimal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
-
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception in version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
 
         return $this->format($number, \NumberFormatter::DECIMAL, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -195,15 +178,6 @@ class NumberHelper extends BaseHelper
             return $this->fixCharset($intlExtension->formatNumberStyle('spellout', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception in version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
-
         return $this->format($number, \NumberFormatter::SPELLOUT, $attributes, $textAttributes, $symbols, $locale);
     }
 
@@ -231,15 +205,6 @@ class NumberHelper extends BaseHelper
 
             return $this->fixCharset($intlExtension->formatCurrency($number, $currency, $attributes, $locale ?: $this->localeDetector->getLocale()));
         }
-
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception in version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
 
         // convert Doctrine's decimal type (fixed-point number represented as string) to float for backward compatibility
         if (\is_string($number) && is_numeric($number)) {
@@ -275,15 +240,6 @@ class NumberHelper extends BaseHelper
             return $this->fixCharset($intlExtension->formatNumberStyle('scientific', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception in version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
-
         return $this->format($number, \NumberFormatter::SCIENTIFIC, $attributes, $textAttributes, $symbols, $locale);
     }
 
@@ -310,15 +266,6 @@ class NumberHelper extends BaseHelper
 
             return $this->fixCharset($intlExtension->formatNumberStyle('ordinal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
-
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception in version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
 
         return $this->format($number, \NumberFormatter::ORDINAL, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -347,15 +294,6 @@ class NumberHelper extends BaseHelper
 
             return $this->fixCharset($intlExtension->formatNumberStyle($style, $number, $attributes, $locale ?: $this->localeDetector->getLocale()));
         }
-
-        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
-
-        @trigger_error(sprintf(
-            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception in version 3.x.',
-            IntlExtension::class,
-            __CLASS__
-        ));
 
         $formatter = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), $style, $attributes, $textAttributes, $symbols);
 

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -76,6 +76,10 @@ class NumberHelper extends BaseHelper
      */
     public function formatPercent($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
             $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::PERCENT, $textAttributes);
@@ -91,10 +95,6 @@ class NumberHelper extends BaseHelper
             IntlExtension::class,
             __CLASS__
         ));
-
-        $methodArgs = array_pad(\func_get_args(), 5, null);
-
-        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
 
         return $this->format($number, \NumberFormatter::PERCENT, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -112,6 +112,10 @@ class NumberHelper extends BaseHelper
      */
     public function formatDuration($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
             $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::DURATION, $textAttributes);
@@ -127,10 +131,6 @@ class NumberHelper extends BaseHelper
             IntlExtension::class,
             __CLASS__
         ));
-
-        $methodArgs = array_pad(\func_get_args(), 5, null);
-
-        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
 
         return $this->format($number, \NumberFormatter::DURATION, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -148,6 +148,10 @@ class NumberHelper extends BaseHelper
      */
     public function formatDecimal($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
             $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::DECIMAL, $textAttributes);
@@ -163,10 +167,6 @@ class NumberHelper extends BaseHelper
             IntlExtension::class,
             __CLASS__
         ));
-
-        $methodArgs = array_pad(\func_get_args(), 5, null);
-
-        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
 
         return $this->format($number, \NumberFormatter::DECIMAL, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -184,6 +184,10 @@ class NumberHelper extends BaseHelper
      */
     public function formatSpellout($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
             $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::SPELLOUT, $textAttributes);
@@ -199,10 +203,6 @@ class NumberHelper extends BaseHelper
             IntlExtension::class,
             __CLASS__
         ));
-
-        $methodArgs = array_pad(\func_get_args(), 5, null);
-
-        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
 
         return $this->format($number, \NumberFormatter::SPELLOUT, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -221,6 +221,10 @@ class NumberHelper extends BaseHelper
      */
     public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        $methodArgs = array_pad(\func_get_args(), 6, null);
+
+        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
+
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
             $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::CURRENCY, $textAttributes);
@@ -242,10 +246,6 @@ class NumberHelper extends BaseHelper
             $number = (float) $number;
         }
 
-        $methodArgs = array_pad(\func_get_args(), 6, null);
-
-        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
-
         $formatter = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), \NumberFormatter::CURRENCY, $attributes, $textAttributes, $symbols);
 
         return $this->fixCharset($formatter->formatCurrency($number, $currency));
@@ -264,6 +264,10 @@ class NumberHelper extends BaseHelper
      */
     public function formatScientific($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
             $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::SCIENTIFIC, $textAttributes);
@@ -279,10 +283,6 @@ class NumberHelper extends BaseHelper
             IntlExtension::class,
             __CLASS__
         ));
-
-        $methodArgs = array_pad(\func_get_args(), 5, null);
-
-        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
 
         return $this->format($number, \NumberFormatter::SCIENTIFIC, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -300,6 +300,10 @@ class NumberHelper extends BaseHelper
      */
     public function formatOrdinal($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
             $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::ORDINAL, $textAttributes);
@@ -315,10 +319,6 @@ class NumberHelper extends BaseHelper
             IntlExtension::class,
             __CLASS__
         ));
-
-        $methodArgs = array_pad(\func_get_args(), 5, null);
-
-        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
 
         return $this->format($number, \NumberFormatter::ORDINAL, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -337,6 +337,10 @@ class NumberHelper extends BaseHelper
      */
     public function format($number, $style, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        $methodArgs = array_pad(\func_get_args(), 6, null);
+
+        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
+
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
             $intlExtension = $this->getIntlExtension($locale, $style, $textAttributes);
@@ -352,10 +356,6 @@ class NumberHelper extends BaseHelper
             IntlExtension::class,
             __CLASS__
         ));
-
-        $methodArgs = array_pad(\func_get_args(), 6, null);
-
-        [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
 
         $formatter = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), $style, $attributes, $textAttributes, $symbols);
 

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -78,8 +78,9 @@ class NumberHelper extends BaseHelper
     {
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::PERCENT, $textAttributes);
 
-            return $this->fixCharset($this->intlExtension->formatNumberStyle('percent', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+            return $this->fixCharset($intlExtension->formatNumberStyle('percent', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
         // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
@@ -113,8 +114,9 @@ class NumberHelper extends BaseHelper
     {
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::DURATION, $textAttributes);
 
-            return $this->fixCharset($this->intlExtension->formatNumberStyle('duration', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+            return $this->fixCharset($intlExtension->formatNumberStyle('duration', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
         // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
@@ -148,8 +150,9 @@ class NumberHelper extends BaseHelper
     {
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::DECIMAL, $textAttributes);
 
-            return $this->fixCharset($this->intlExtension->formatNumberStyle('decimal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+            return $this->fixCharset($intlExtension->formatNumberStyle('decimal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
         // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
@@ -183,8 +186,9 @@ class NumberHelper extends BaseHelper
     {
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::SPELLOUT, $textAttributes);
 
-            return $this->fixCharset($this->intlExtension->formatNumberStyle('spellout', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+            return $this->fixCharset($intlExtension->formatNumberStyle('spellout', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
         // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
@@ -219,8 +223,9 @@ class NumberHelper extends BaseHelper
     {
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::CURRENCY, $textAttributes);
 
-            return $this->fixCharset($this->intlExtension->formatCurrency($number, $currency, $attributes, $locale ?: $this->localeDetector->getLocale()));
+            return $this->fixCharset($intlExtension->formatCurrency($number, $currency, $attributes, $locale ?: $this->localeDetector->getLocale()));
         }
 
         // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
@@ -261,8 +266,9 @@ class NumberHelper extends BaseHelper
     {
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::SCIENTIFIC, $textAttributes);
 
-            return $this->fixCharset($this->intlExtension->formatNumberStyle('scientific', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+            return $this->fixCharset($intlExtension->formatNumberStyle('scientific', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
         // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
@@ -296,8 +302,9 @@ class NumberHelper extends BaseHelper
     {
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, \NumberFormatter::ORDINAL, $textAttributes);
 
-            return $this->fixCharset($this->intlExtension->formatNumberStyle('ordinal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+            return $this->fixCharset($intlExtension->formatNumberStyle('ordinal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
         }
 
         // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
@@ -332,8 +339,9 @@ class NumberHelper extends BaseHelper
     {
         if ($this->intlExtension) {
             $attributes = self::processLegacyAttributes($attributes);
+            $intlExtension = $this->getIntlExtension($locale, $style, $textAttributes);
 
-            return $this->fixCharset($this->intlExtension->formatNumber($number, $attributes, $style, 'default', $locale ?: $this->localeDetector->getLocale()));
+            return $this->fixCharset($intlExtension->formatNumberStyle($style, $number, $attributes, $locale ?: $this->localeDetector->getLocale()));
         }
 
         // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
@@ -406,12 +414,8 @@ class NumberHelper extends BaseHelper
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
-     *
      * Gets an instance of \NumberFormatter set with the given attributes and
      * style.
-     *
-     * @deprecated since sonata-project/intl-bundle 2.x
      *
      * @param string $culture        The culture used by \NumberFormatter
      * @param string $style          The style used by \NumberFormatter
@@ -423,12 +427,6 @@ class NumberHelper extends BaseHelper
      */
     protected function getFormatter($culture, $style, $attributes = [], $textAttributes = [], $symbols = [])
     {
-        @trigger_error(sprintf(
-            'Method "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will be removed in version 3.x.',
-            __METHOD__
-        ));
-
         $attributes = $this->parseAttributes(array_merge($this->attributes, $attributes));
         $textAttributes = $this->parseAttributes(array_merge($this->textAttributes, $textAttributes));
         $symbols = $this->parseAttributes(array_merge($this->symbols, $symbols));
@@ -528,5 +526,16 @@ class NumberHelper extends BaseHelper
         }
 
         return $attributes;
+    }
+
+    private function getIntlExtension(?string $locale = null, int $style, array $textAttributes): IntlExtension
+    {
+        if (empty($textAttributes)) {
+            return $this->intlExtension;
+        }
+
+        $numberFormatterProto = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), $style, [], $textAttributes);
+
+        return new IntlExtension(null, $numberFormatterProto);
     }
 }

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -14,9 +14,12 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Templating\Helper;
 
 use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
+use Twig\Extra\Intl\IntlExtension;
 
 /**
  * NumberHelper displays culture information.
+ *
+ * @final since sonata-project/intl-bundle 2.x
  *
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  * @author Stefano Arlandini <sarlandini@alice.it>
@@ -39,19 +42,25 @@ class NumberHelper extends BaseHelper
     protected $symbols = [];
 
     /**
+     * @var IntlExtension|null
+     */
+    private $intlExtension;
+
+    /**
      * @param string                  $charset        The output charset of the helper
      * @param LocaleDetectorInterface $localeDetector A locale detector instance
      * @param array                   $attributes     The default attributes to apply to the \NumberFormatter instance
      * @param array                   $textAttributes The default text attributes to apply to the \NumberFormatter instance
      * @param array                   $symbols        The default symbols to apply to the \NumberFormatter instance
      */
-    public function __construct($charset, LocaleDetectorInterface $localeDetector, array $attributes = [], array $textAttributes = [], array $symbols = [])
+    public function __construct($charset, LocaleDetectorInterface $localeDetector, array $attributes = [], array $textAttributes = [], array $symbols = [], ?IntlExtension $intlExtension = null)
     {
         parent::__construct($charset, $localeDetector);
 
         $this->attributes = $attributes;
         $this->textAttributes = $textAttributes;
         $this->symbols = $symbols;
+        $this->intlExtension = $intlExtension;
     }
 
     /**
@@ -67,6 +76,21 @@ class NumberHelper extends BaseHelper
      */
     public function formatPercent($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+
+            return $this->fixCharset($this->intlExtension->formatNumberStyle('percent', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
@@ -87,6 +111,21 @@ class NumberHelper extends BaseHelper
      */
     public function formatDuration($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+
+            return $this->fixCharset($this->intlExtension->formatNumberStyle('duration', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
@@ -107,6 +146,21 @@ class NumberHelper extends BaseHelper
      */
     public function formatDecimal($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+
+            return $this->fixCharset($this->intlExtension->formatNumberStyle('decimal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
@@ -127,6 +181,21 @@ class NumberHelper extends BaseHelper
      */
     public function formatSpellout($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+
+            return $this->fixCharset($this->intlExtension->formatNumberStyle('spellout', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
@@ -148,6 +217,21 @@ class NumberHelper extends BaseHelper
      */
     public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+
+            return $this->fixCharset($this->intlExtension->formatCurrency($number, $currency, $attributes, $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         // convert Doctrine's decimal type (fixed-point number represented as string) to float for backward compatibility
         if (\is_string($number) && is_numeric($number)) {
             $number = (float) $number;
@@ -175,6 +259,21 @@ class NumberHelper extends BaseHelper
      */
     public function formatScientific($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+
+            return $this->fixCharset($this->intlExtension->formatNumberStyle('scientific', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
@@ -195,6 +294,21 @@ class NumberHelper extends BaseHelper
      */
     public function formatOrdinal($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+
+            return $this->fixCharset($this->intlExtension->formatNumberStyle('ordinal', $number, $attributes, 'default', $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
@@ -216,6 +330,21 @@ class NumberHelper extends BaseHelper
      */
     public function format($number, $style, array $attributes = [], array $textAttributes = [], $locale = null)
     {
+        if ($this->intlExtension) {
+            $attributes = self::processLegacyAttributes($attributes);
+
+            return $this->fixCharset($this->intlExtension->formatNumber($number, $attributes, $style, 'default', $locale ?: $this->localeDetector->getLocale()));
+        }
+
+        // NEXT_MAJOR: Execute the previous block unconditionally and remove following lines in this method.
+
+        @trigger_error(sprintf(
+            'Not passing an instance of "%s" as argument 6 for %s::__construct() is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            __CLASS__
+        ));
+
         $methodArgs = array_pad(\func_get_args(), 6, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
@@ -226,9 +355,13 @@ class NumberHelper extends BaseHelper
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Normalizes the given arguments according to the new function signature.
      * It asserts if neither the new nor old signature matches. This function
      * is public just to prevent code duplication inside the Twig Extension.
+     *
+     * @deprecated since sonata-project/intl-bundle 2.x
      *
      * @param mixed $symbols The symbols used by the formatter
      * @param mixed $locale  The locale
@@ -241,6 +374,12 @@ class NumberHelper extends BaseHelper
      */
     public function normalizeMethodSignature($symbols, $locale)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will be removed in version 3.x.',
+            __METHOD__
+        ));
+
         $oldSignature = (null === $symbols || \is_string($symbols)) && null === $locale;
         $newSignature = \is_array($symbols) && (\is_string($locale) || null === $locale);
 
@@ -267,8 +406,12 @@ class NumberHelper extends BaseHelper
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Gets an instance of \NumberFormatter set with the given attributes and
      * style.
+     *
+     * @deprecated since sonata-project/intl-bundle 2.x
      *
      * @param string $culture        The culture used by \NumberFormatter
      * @param string $style          The style used by \NumberFormatter
@@ -280,6 +423,12 @@ class NumberHelper extends BaseHelper
      */
     protected function getFormatter($culture, $style, $attributes = [], $textAttributes = [], $symbols = [])
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will be removed in version 3.x.',
+            __METHOD__
+        ));
+
         $attributes = $this->parseAttributes(array_merge($this->attributes, $attributes));
         $textAttributes = $this->parseAttributes(array_merge($this->textAttributes, $textAttributes));
         $symbols = $this->parseAttributes(array_merge($this->symbols, $symbols));
@@ -306,7 +455,11 @@ class NumberHelper extends BaseHelper
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Converts keys of attributes array to values of \NumberFormatter constants.
+     *
+     * @deprecated since sonata-project/intl-bundle 2.x
      *
      * @param array $attributes The list of attributes
      *
@@ -316,6 +469,12 @@ class NumberHelper extends BaseHelper
      */
     protected function parseAttributes(array $attributes)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will be removed in version 3.x.',
+            __METHOD__
+        ));
+
         $result = [];
 
         foreach ($attributes as $attribute => $value) {
@@ -326,7 +485,11 @@ class NumberHelper extends BaseHelper
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Parse the given value trying to get a match with a \NumberFormatter constant.
+     *
+     * @deprecated since sonata-project/intl-bundle 2.x
      *
      * @param string $attribute The constant's name
      *
@@ -336,6 +499,12 @@ class NumberHelper extends BaseHelper
      */
     protected function parseConstantValue($attribute)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will be removed in version 3.x.',
+            __METHOD__
+        ));
+
         $attribute = strtoupper($attribute);
         $constantName = 'NumberFormatter::'.$attribute;
 
@@ -344,5 +513,20 @@ class NumberHelper extends BaseHelper
         }
 
         return \constant($constantName);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * Replaces legacy attribute names with its new variants.
+     */
+    private static function processLegacyAttributes(array $attributes): array
+    {
+        if (isset($attributes['fraction_digits'])) {
+            $curatedAttributes['fraction_digit'] = $attributes['fraction_digits'];
+            unset($attributes['fraction_digits']);
+        }
+
+        return $attributes;
     }
 }

--- a/src/Twig/Extension/LocaleExtension.php
+++ b/src/Twig/Extension/LocaleExtension.php
@@ -20,6 +20,8 @@ use Twig\TwigFilter;
 /**
  * LocaleExtension extends Twig with local capabilities.
  *
+ * @final since sonata-project/intl-bundle 2.x
+ *
  * @author Thomas Rabaix <thomas.rabaix@ekino.com>
  */
 class LocaleExtension extends AbstractExtension

--- a/tests/Helper/LocaleHelperTest.php
+++ b/tests/Helper/LocaleHelperTest.php
@@ -16,11 +16,14 @@ namespace Sonata\IntlBundle\Tests\Helper;
 use PHPUnit\Framework\TestCase;
 use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Sonata\IntlBundle\Templating\Helper\LocaleHelper;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Templating\Helper\HelperInterface;
 use Twig\Extra\Intl\IntlExtension;
 
 final class LocaleHelperTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * NEXT_MAJOR: Remove this property.
      *
@@ -79,6 +82,13 @@ final class LocaleHelperTest extends TestCase
      */
     public function testLegacyLanguage(): void
     {
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s" as argument 3 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception since version 3.x.',
+            IntlExtension::class,
+            LocaleHelper::class
+        ));
+
         $this->assertSame('français', $this->legacyLocaleHelper->language('fr'));
         $this->assertSame('français', $this->legacyLocaleHelper->language('fr_FR'));
         $this->assertSame('anglais américain', $this->legacyLocaleHelper->language('en_US'));

--- a/tests/Helper/LocaleHelperTest.php
+++ b/tests/Helper/LocaleHelperTest.php
@@ -16,48 +16,97 @@ namespace Sonata\IntlBundle\Tests\Helper;
 use PHPUnit\Framework\TestCase;
 use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Sonata\IntlBundle\Templating\Helper\LocaleHelper;
+use Symfony\Component\Templating\Helper\HelperInterface;
+use Twig\Extra\Intl\IntlExtension;
 
-class LocaleHelperTest extends TestCase
+final class LocaleHelperTest extends TestCase
 {
-    public function getHelper()
+    /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @var HelperInterface
+     */
+    private $legacyLocaleHelper;
+
+    /**
+     * @var HelperInterface
+     */
+    private $localeHelper;
+
+    protected function setUp(): void
     {
         $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector
             ->method('getLocale')->willReturn('fr');
 
-        return new LocaleHelper('UTF-8', $localeDetector);
+        $this->localeHelper = new LocaleHelper('UTF-8', $localeDetector, new IntlExtension());
+        $this->legacyLocaleHelper = new LocaleHelper('UTF-8', $localeDetector);
     }
 
     /**
      * @group legacy
      */
-    public function testLanguage()
+    public function testLanguage(): void
     {
-        $helper = $this->getHelper();
-        $this->assertSame('français', $helper->language('fr'));
-        $this->assertSame('français', $helper->language('fr_FR'));
-        $this->assertSame('anglais américain', $helper->language('en_US'));
-        $this->assertSame('French', $helper->language('fr', 'en'));
+        $this->assertSame('français', $this->localeHelper->language('fr'));
+        $this->assertSame('français', $this->localeHelper->language('fr_FR'));
+        $this->assertSame('anglais américain', $this->localeHelper->language('en_US'));
+        $this->assertSame('French', $this->localeHelper->language('fr', 'en'));
     }
 
-    public function testCountry()
+    public function testCountry(): void
     {
-        $helper = $this->getHelper();
-        $this->assertSame('France', $helper->country('FR'));
-        $this->assertSame('France', $helper->country('FR', 'en'));
-        //        $this->assertEquals('', $helper->country('FR', 'fake'));
+        $this->assertSame('France', $this->localeHelper->country('FR'));
+        $this->assertSame('France', $this->localeHelper->country('FR', 'en'));
+        //        $this->assertEquals('', $this->localeHelper->country('FR', 'fake'));
     }
 
-    public function testLocale()
+    public function testLocale(): void
     {
-        $helper = $this->getHelper();
+        $this->assertSame('français', $this->localeHelper->locale('fr'));
+        $this->assertSame('français (Canada)', $this->localeHelper->locale('fr_CA'));
 
-        $this->assertSame('français', $helper->locale('fr'));
-        $this->assertSame('français (Canada)', $helper->locale('fr_CA'));
+        $this->assertSame('French', $this->localeHelper->locale('fr', 'en'));
+        $this->assertSame('French (Canada)', $this->localeHelper->locale('fr_CA', 'en'));
+        //        $this->assertEquals('', $this->localeHelper->locale('fr', 'fake'));
+        //        $this->assertEquals('', $this->localeHelper->locale('fr_CA', 'fake'));
+    }
 
-        $this->assertSame('French', $helper->locale('fr', 'en'));
-        $this->assertSame('French (Canada)', $helper->locale('fr_CA', 'en'));
-        //        $this->assertEquals('', $helper->locale('fr', 'fake'));
-        //        $this->assertEquals('', $helper->locale('fr_CA', 'fake'));
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
+    public function testLegacyLanguage(): void
+    {
+        $this->assertSame('français', $this->legacyLocaleHelper->language('fr'));
+        $this->assertSame('français', $this->legacyLocaleHelper->language('fr_FR'));
+        $this->assertSame('anglais américain', $this->legacyLocaleHelper->language('en_US'));
+        $this->assertSame('French', $this->legacyLocaleHelper->language('fr', 'en'));
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
+    public function testLegacyCountry(): void
+    {
+        $this->assertSame('France', $this->legacyLocaleHelper->country('FR'));
+        $this->assertSame('France', $this->legacyLocaleHelper->country('FR', 'en'));
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
+    public function testLegacyLocale(): void
+    {
+        $this->assertSame('français', $this->legacyLocaleHelper->locale('fr'));
+        $this->assertSame('français (Canada)', $this->legacyLocaleHelper->locale('fr_CA'));
+
+        $this->assertSame('French', $this->legacyLocaleHelper->locale('fr', 'en'));
+        $this->assertSame('French (Canada)', $this->legacyLocaleHelper->locale('fr_CA', 'en'));
     }
 }

--- a/tests/Helper/LocaleHelperTest.php
+++ b/tests/Helper/LocaleHelperTest.php
@@ -27,9 +27,9 @@ final class LocaleHelperTest extends TestCase
     /**
      * NEXT_MAJOR: Remove this property.
      *
-     * @var HelperInterface
+     * @var LocaleDetectorInterface
      */
-    private $legacyLocaleHelper;
+    private $localeDetector;
 
     /**
      * @var HelperInterface
@@ -43,12 +43,10 @@ final class LocaleHelperTest extends TestCase
             ->method('getLocale')->willReturn('fr');
 
         $this->localeHelper = new LocaleHelper('UTF-8', $localeDetector, new IntlExtension());
-        $this->legacyLocaleHelper = new LocaleHelper('UTF-8', $localeDetector);
+        // NEXT_MAJOR: Remove the following assignment.
+        $this->localeDetector = $localeDetector;
     }
 
-    /**
-     * @group legacy
-     */
     public function testLanguage(): void
     {
         $this->assertSame('français', $this->localeHelper->language('fr'));
@@ -83,16 +81,18 @@ final class LocaleHelperTest extends TestCase
     public function testLegacyLanguage(): void
     {
         $this->expectDeprecation(sprintf(
-            'Not passing an instance of "%s" as argument 3 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception since version 3.x.',
+            'Not passing an instance of "%s" as argument 3 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
             IntlExtension::class,
             LocaleHelper::class
         ));
 
-        $this->assertSame('français', $this->legacyLocaleHelper->language('fr'));
-        $this->assertSame('français', $this->legacyLocaleHelper->language('fr_FR'));
-        $this->assertSame('anglais américain', $this->legacyLocaleHelper->language('en_US'));
-        $this->assertSame('French', $this->legacyLocaleHelper->language('fr', 'en'));
+        $localeHelper = $this->createLegacyLocaleHelper();
+
+        $this->assertSame('français', $localeHelper->language('fr'));
+        $this->assertSame('français', $localeHelper->language('fr_FR'));
+        $this->assertSame('anglais américain', $localeHelper->language('en_US'));
+        $this->assertSame('French', $localeHelper->language('fr', 'en'));
     }
 
     /**
@@ -102,8 +102,17 @@ final class LocaleHelperTest extends TestCase
      */
     public function testLegacyCountry(): void
     {
-        $this->assertSame('France', $this->legacyLocaleHelper->country('FR'));
-        $this->assertSame('France', $this->legacyLocaleHelper->country('FR', 'en'));
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s" as argument 3 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            LocaleHelper::class
+        ));
+
+        $localeHelper = $this->createLegacyLocaleHelper();
+
+        $this->assertSame('France', $localeHelper->country('FR'));
+        $this->assertSame('France', $localeHelper->country('FR', 'en'));
     }
 
     /**
@@ -113,10 +122,27 @@ final class LocaleHelperTest extends TestCase
      */
     public function testLegacyLocale(): void
     {
-        $this->assertSame('français', $this->legacyLocaleHelper->locale('fr'));
-        $this->assertSame('français (Canada)', $this->legacyLocaleHelper->locale('fr_CA'));
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s" as argument 3 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            LocaleHelper::class
+        ));
 
-        $this->assertSame('French', $this->legacyLocaleHelper->locale('fr', 'en'));
-        $this->assertSame('French (Canada)', $this->legacyLocaleHelper->locale('fr_CA', 'en'));
+        $localeHelper = $this->createLegacyLocaleHelper();
+
+        $this->assertSame('français', $localeHelper->locale('fr'));
+        $this->assertSame('français (Canada)', $localeHelper->locale('fr_CA'));
+
+        $this->assertSame('French', $localeHelper->locale('fr', 'en'));
+        $this->assertSame('French (Canada)', $localeHelper->locale('fr_CA', 'en'));
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
+    private function createLegacyLocaleHelper(): LocaleHelper
+    {
+        return new LocaleHelper('UTF-8', $this->localeDetector);
     }
 }

--- a/tests/Helper/LocaleHelperTest.php
+++ b/tests/Helper/LocaleHelperTest.php
@@ -38,6 +38,8 @@ final class LocaleHelperTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $localeDetector = $this->createMock(LocaleDetectorInterface::class);
         $localeDetector
             ->method('getLocale')->willReturn('fr');

--- a/tests/Helper/NumberHelperTest.php
+++ b/tests/Helper/NumberHelperTest.php
@@ -33,6 +33,8 @@ final class NumberHelperTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->localeDetector = $this->createStub(LocaleDetectorInterface::class);
         $this->localeDetector
             ->method('getLocale')

--- a/tests/Helper/NumberHelperTest.php
+++ b/tests/Helper/NumberHelperTest.php
@@ -99,8 +99,8 @@ final class NumberHelperTest extends TestCase
     public function testLegacyLocale(): void
     {
         $this->expectDeprecation(sprintf(
-            'Not passing an instance of "%s::__construct()" as argument 3 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x.'
-            .' and will throw an exception since version 3.x.',
+            'Not passing an instance of "%s" as argument 6 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
             IntlExtension::class,
             NumberHelper::class
         ));
@@ -155,8 +155,18 @@ final class NumberHelperTest extends TestCase
         $this->assertSame('10,000th', $helper->formatOrdinal(10000), 'ICU Version: '.NumberHelper::getICUDataVersion());
     }
 
+    /**
+     * @group legacy
+     */
     public function testArguments(): void
     {
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s" as argument 6 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            NumberHelper::class
+        ));
+
         $helper = new NumberHelper('UTF-8', $this->localeDetector, ['fraction_digits' => 2], ['negative_prefix' => 'MINUS']);
 
         // Check that the 'default' options are used
@@ -177,10 +187,19 @@ final class NumberHelperTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider provideConstantValues
      */
     public function testParseConstantValue(string $constantName, int $expectedConstant, bool $exceptionExpected): void
     {
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s" as argument 6 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            NumberHelper::class
+        ));
+
         $helper = new NumberHelper('UTF-8', $this->localeDetector);
         $method = new \ReflectionMethod($helper, 'parseConstantValue');
         $method->setAccessible(true);
@@ -201,10 +220,19 @@ final class NumberHelperTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider provideAttributeValues
      */
     public function testParseAttributes(array $attributes, array $expectedAttributes, bool $exceptionExpected): void
     {
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s" as argument 6 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            NumberHelper::class
+        ));
+
         $helper = new NumberHelper('UTF-8', $this->localeDetector);
         $method = new \ReflectionMethod($helper, 'parseAttributes');
         $method->setAccessible(true);
@@ -241,10 +269,19 @@ final class NumberHelperTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider provideFormatMethodArguments
      */
     public function testFormatMethodSignatures(array $arguments, array $expectedArguments, bool $exceptionExpected): void
     {
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s" as argument 6 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            NumberHelper::class
+        ));
+
         $helper = new NumberHelper('UTF-8', $this->localeDetector);
 
         if ($exceptionExpected) {
@@ -285,8 +322,18 @@ final class NumberHelperTest extends TestCase
         ];
     }
 
+    /**
+     * @group legacy
+     */
     public function testFormatMethodWithDefaultArguments(): void
     {
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s" as argument 6 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x'
+            .' and will throw an exception in version 3.x.',
+            IntlExtension::class,
+            NumberHelper::class
+        ));
+
         $helper = new NumberHelper('UTF-8', $this->localeDetector);
         $method = new \ReflectionMethod($helper, 'format');
         $method->setAccessible(true);

--- a/tests/Helper/NumberHelperTest.php
+++ b/tests/Helper/NumberHelperTest.php
@@ -48,6 +48,8 @@ final class NumberHelperTest extends TestCase
         // test compatibility with Doctrine's decimal type (fixed-point number represented as string)
         $this->assertSame('€10.49', $helper->formatCurrency('10.49', 'EUR'));
 
+        $this->assertSame('€10.49', $helper->formatCurrency('10.49', 'EUR', [], [], ['positive_prefix' => ' ++']));
+
         $this->assertSame('€10.49', $helper->formatCurrency(10.49, 'EUR', [
             // the fraction_digits is not supported by the currency lib, https://bugs.php.net/bug.php?id=63140
             'fraction_digits' => 0,
@@ -102,6 +104,8 @@ final class NumberHelperTest extends TestCase
 
         // test compatibility with Doctrine's decimal type (fixed-point number represented as string)
         $this->assertSame('€10.49', $helper->formatCurrency('10.49', 'EUR'));
+
+        $this->assertSame('€10.49', $helper->formatCurrency('10.49', 'EUR', [], [], ['positive_prefix' => ' ++']));
 
         $this->assertSame('€10.49', $helper->formatCurrency(10.49, 'EUR', [
             // the fraction_digits is not supported by the currency lib, https://bugs.php.net/bug.php?id=63140

--- a/tests/Helper/NumberHelperTest.php
+++ b/tests/Helper/NumberHelperTest.php
@@ -76,6 +76,7 @@ final class NumberHelperTest extends TestCase
 
         // percent
         $this->assertSame('10%', $helper->formatPercent(0.1));
+        $this->assertSame('+ 10%', $helper->formatPercent(0.1, [], ['positive_prefix' => '+ ']));
         $this->assertSame('200%', $helper->formatPercent(1.999));
         $this->assertSame('99%', $helper->formatPercent(0.99));
 
@@ -130,6 +131,7 @@ final class NumberHelperTest extends TestCase
 
         // percent
         $this->assertSame('10%', $helper->formatPercent(0.1));
+        $this->assertSame('+ 10%', $helper->formatPercent(0.1, [], ['positive_prefix' => '+ ']));
         $this->assertSame('200%', $helper->formatPercent(1.999));
         $this->assertSame('99%', $helper->formatPercent(0.99));
 

--- a/tests/Helper/NumberHelperTest.php
+++ b/tests/Helper/NumberHelperTest.php
@@ -16,16 +16,29 @@ namespace Sonata\IntlBundle\Tests\Helper;
 use PHPUnit\Framework\TestCase;
 use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Twig\Extra\Intl\IntlExtension;
 
 /**
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class NumberHelperTest extends TestCase
+final class NumberHelperTest extends TestCase
 {
-    public function testLocale()
+    /**
+     * @var LocaleDetectorInterface
+     */
+    private $localeDetector;
+
+    protected function setUp(): void
     {
-        $localeDetector = $this->createLocaleDetectorMock();
-        $helper = new NumberHelper('UTF-8', $localeDetector);
+        $this->localeDetector = $this->createStub(LocaleDetectorInterface::class);
+        $this->localeDetector
+            ->method('getLocale')
+            ->willReturn('en');
+    }
+
+    public function testLocale(): void
+    {
+        $helper = new NumberHelper('UTF-8', $this->localeDetector, [], [], [], new IntlExtension());
 
         // currency
         $this->assertSame('€10.49', $helper->formatCurrency(10.49, 'EUR'));
@@ -72,10 +85,63 @@ class NumberHelperTest extends TestCase
         $this->assertSame('10,000th', $helper->formatOrdinal(10000), 'ICU Version: '.NumberHelper::getICUDataVersion());
     }
 
-    public function testArguments()
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
+    public function testLegacyLocale(): void
     {
-        $localeDetector = $this->createLocaleDetectorMock();
-        $helper = new NumberHelper('UTF-8', $localeDetector, ['fraction_digits' => 2], ['negative_prefix' => 'MINUS']);
+        $helper = new NumberHelper('UTF-8', $this->localeDetector);
+
+        // currency
+        $this->assertSame('€10.49', $helper->formatCurrency(10.49, 'EUR'));
+        $this->assertSame('€10.50', $helper->formatCurrency(10.499, 'EUR'));
+        $this->assertSame('€10,000.50', $helper->formatCurrency(10000.499, 'EUR'));
+
+        // test compatibility with Doctrine's decimal type (fixed-point number represented as string)
+        $this->assertSame('€10.49', $helper->formatCurrency('10.49', 'EUR'));
+
+        $this->assertSame('€10.49', $helper->formatCurrency(10.49, 'EUR', [
+            // the fraction_digits is not supported by the currency lib, https://bugs.php.net/bug.php?id=63140
+            'fraction_digits' => 0,
+        ]));
+
+        // decimal
+        $this->assertSame('10', $helper->formatDecimal(10));
+        $this->assertSame('10.155', $helper->formatDecimal(10.15459));
+        $this->assertSame('1,000,000.155', $helper->formatDecimal(1000000.15459));
+
+        // scientific
+        $this->assertSame('1E1', $helper->formatScientific(10));
+        $this->assertSame('1E3', $helper->formatScientific(1000));
+        $this->assertSame('1.0001E3', $helper->formatScientific(1000.1));
+        $this->assertSame('1.00000015459E6', $helper->formatScientific(1000000.15459));
+        $this->assertSame('1.00000015459E6', $helper->formatScientific(1000000.15459));
+
+        // duration
+        $this->assertSame('277:46:40', $helper->formatDuration(1000000));
+
+        // spell out
+        $this->assertSame('one', $helper->formatSpellout(1));
+        $this->assertSame('forty-two', $helper->formatSpellout(42));
+
+        $this->assertSame('one million two hundred twenty-four thousand five hundred fifty-seven point one two five four', $helper->formatSpellout(1224557.1254));
+
+        // percent
+        $this->assertSame('10%', $helper->formatPercent(0.1));
+        $this->assertSame('200%', $helper->formatPercent(1.999));
+        $this->assertSame('99%', $helper->formatPercent(0.99));
+
+        // ordinal
+        $this->assertSame('1st', $helper->formatOrdinal(1), 'ICU Version: '.NumberHelper::getICUDataVersion());
+        $this->assertSame('100th', $helper->formatOrdinal(100), 'ICU Version: '.NumberHelper::getICUDataVersion());
+        $this->assertSame('10,000th', $helper->formatOrdinal(10000), 'ICU Version: '.NumberHelper::getICUDataVersion());
+    }
+
+    public function testArguments(): void
+    {
+        $helper = new NumberHelper('UTF-8', $this->localeDetector, ['fraction_digits' => 2], ['negative_prefix' => 'MINUS']);
 
         // Check that the 'default' options are used
         $this->assertSame('1.34', $helper->formatDecimal(1.337));
@@ -86,35 +152,20 @@ class NumberHelperTest extends TestCase
         $this->assertSame('MIN1.34', $helper->formatDecimal(-1.337, [], ['negative_prefix' => 'MIN']));
     }
 
-    public function testExceptionOnInvalidParams()
+    public function testExceptionOnInvalidParams(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\IntlException::class);
 
         // https://wiki.php.net/rfc/internal_constructor_behaviour
-        try {
-            $formatter = new \NumberFormatter('EN', -1);
-        } catch (\IntlException $e) {
-            throw new \RuntimeException($e->getMessage());
-        }
-
-        $this->assertNull($formatter);
-
-        $localeDetector = $this->createMock(LocaleDetectorInterface::class);
-        $localeDetector
-            ->method('getLocale')->willReturn('en');
-
-        $helper = new NumberHelper('UTF-8', $localeDetector, ['fraction_digits' => 2], ['negative_prefix' => 'MINUS']);
-
-        $helper->format(10.49, -1);
+        $formatter = new \NumberFormatter('EN', -1);
     }
 
     /**
      * @dataProvider provideConstantValues
      */
-    public function testParseConstantValue($constantName, $expectedConstant, $exceptionExpected)
+    public function testParseConstantValue(string $constantName, int $expectedConstant, bool $exceptionExpected): void
     {
-        $localeDetector = $this->createLocaleDetectorMock();
-        $helper = new NumberHelper('UTF-8', $localeDetector);
+        $helper = new NumberHelper('UTF-8', $this->localeDetector);
         $method = new \ReflectionMethod($helper, 'parseConstantValue');
         $method->setAccessible(true);
 
@@ -125,7 +176,7 @@ class NumberHelperTest extends TestCase
         $this->assertSame($expectedConstant, $method->invoke($helper, $constantName));
     }
 
-    public function provideConstantValues()
+    public function provideConstantValues(): iterable
     {
         return [
             ['positive_prefix', \NumberFormatter::POSITIVE_PREFIX, false],
@@ -136,10 +187,9 @@ class NumberHelperTest extends TestCase
     /**
      * @dataProvider provideAttributeValues
      */
-    public function testParseAttributes($attributes, $expectedAttributes, $exceptionExpected)
+    public function testParseAttributes(array $attributes, array $expectedAttributes, bool $exceptionExpected): void
     {
-        $localeDetector = $this->createLocaleDetectorMock();
-        $helper = new NumberHelper('UTF-8', $localeDetector);
+        $helper = new NumberHelper('UTF-8', $this->localeDetector);
         $method = new \ReflectionMethod($helper, 'parseAttributes');
         $method->setAccessible(true);
 
@@ -150,7 +200,7 @@ class NumberHelperTest extends TestCase
         $this->assertSame($expectedAttributes, $method->invoke($helper, $attributes));
     }
 
-    public function provideAttributeValues()
+    public function provideAttributeValues(): iterable
     {
         return [
             [
@@ -177,10 +227,9 @@ class NumberHelperTest extends TestCase
     /**
      * @dataProvider provideFormatMethodArguments
      */
-    public function testFormatMethodSignatures($arguments, $expectedArguments, $exceptionExpected)
+    public function testFormatMethodSignatures(array $arguments, array $expectedArguments, bool $exceptionExpected): void
     {
-        $localeDetector = $this->createLocaleDetectorMock();
-        $helper = new NumberHelper('UTF-8', $localeDetector);
+        $helper = new NumberHelper('UTF-8', $this->localeDetector);
 
         if ($exceptionExpected) {
             $this->expectException(\BadMethodCallException::class);
@@ -189,7 +238,7 @@ class NumberHelperTest extends TestCase
         $this->assertSame($expectedArguments, \call_user_func_array([$helper, 'normalizeMethodSignature'], $arguments));
     }
 
-    public function provideFormatMethodArguments()
+    public function provideFormatMethodArguments(): iterable
     {
         return [
             [
@@ -220,25 +269,14 @@ class NumberHelperTest extends TestCase
         ];
     }
 
-    public function testFormatMethodWithDefaultArguments()
+    public function testFormatMethodWithDefaultArguments(): void
     {
-        $localeDetector = $this->createLocaleDetectorMock();
-        $helper = new NumberHelper('UTF-8', $localeDetector);
+        $helper = new NumberHelper('UTF-8', $this->localeDetector);
         $method = new \ReflectionMethod($helper, 'format');
         $method->setAccessible(true);
 
         $this->assertSame('10', $method->invoke($helper, 10, \NumberFormatter::DECIMAL, [], []));
         $this->assertSame('10', $method->invoke($helper, 10, \NumberFormatter::DECIMAL, [], [], 'fr'));
         $this->assertSame('10', $method->invoke($helper, 10, \NumberFormatter::DECIMAL, [], [], []));
-    }
-
-    private function createLocaleDetectorMock()
-    {
-        $localeDetector = $this->createMock(LocaleDetectorInterface::class);
-        $localeDetector
-            ->method('getLocale')->willReturn('en')
-        ;
-
-        return $localeDetector;
     }
 }

--- a/tests/Helper/NumberHelperTest.php
+++ b/tests/Helper/NumberHelperTest.php
@@ -16,6 +16,7 @@ namespace Sonata\IntlBundle\Tests\Helper;
 use PHPUnit\Framework\TestCase;
 use Sonata\IntlBundle\Locale\LocaleDetectorInterface;
 use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Twig\Extra\Intl\IntlExtension;
 
 /**
@@ -23,6 +24,8 @@ use Twig\Extra\Intl\IntlExtension;
  */
 final class NumberHelperTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var LocaleDetectorInterface
      */
@@ -95,6 +98,13 @@ final class NumberHelperTest extends TestCase
      */
     public function testLegacyLocale(): void
     {
+        $this->expectDeprecation(sprintf(
+            'Not passing an instance of "%s::__construct()" as argument 3 for "%s::__construct()" is deprecated since sonata-project/intl-bundle 2.x.'
+            .' and will throw an exception since version 3.x.',
+            IntlExtension::class,
+            NumberHelper::class
+        ));
+
         $helper = new NumberHelper('UTF-8', $this->localeDetector);
 
         // currency


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Require "twig/intl-extra".
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to sonata-project/SonataAdminBundle#5973.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added requirement against "twig/intl-extra".

### Deprecated
- Deprecated not passing `Twig\Extra\Intl\IntlExtension` as argument 3 for `Sonata\IntlBundle\Templating\Helper\LocaleHelper`.
- Deprecated not passing `Twig\Extra\Intl\IntlExtension` as argument 6 for `Sonata\IntlBundle\Templating\Helper\NumberHelper`.
```

## To do

- [x] Update the tests;
- [x] Update the documentation;
- [x] Add an upgrade note;
- [x] Check how to use `$textAttributes` argument from `NumberExtension` methods;
- [ ] Check how to use `$symbols` argument from `NumberExtension` methods;
