### PR TITLE
Bump "symfony/phpunit-bridge" constraint to "^5.1"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "sonata-project/user-bundle": "^3.6 || ^4.0",
-        "symfony/phpunit-bridge": "^5.0",
+        "symfony/phpunit-bridge": "^5.1",
         "symfony/security-core": "^4.4"
     },
     "config": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Bump "symfony/phpunit-bridge" constraint to "^5.1", in order to avoid conflicts with `TestCase::expectDeprecation()`.

See symfony/symfony#37153.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Triggered by https://github.com/sonata-project/SonataIntlBundle/pull/302#issuecomment-640256919.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed exception thrown when calling `self::expectDeprecation()` from the test suite.
```
