### PR TITLE
[WIP] Support Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/config": "^4.4",
-        "symfony/dependency-injection": "^4.4",
-        "symfony/http-foundation": "^4.4",
-        "symfony/http-kernel": "^4.4",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/http-foundation": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
         "symfony/intl": "^4.4 || ^5.0",
-        "symfony/templating": "^4.4",
+        "symfony/templating": "^4.4 || ^5.0",
         "twig/twig": "^2.9"
     },
     "conflict": {
@@ -36,9 +36,8 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "sonata-project/user-bundle": "^3.6 || ^4.0",
         "symfony/phpunit-bridge": "^5.1",
-        "symfony/security-core": "^4.4"
+        "symfony/security-core": "^4.4 || ^5.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
## Subject

This PR adds support for Symfony 5. The UserBundle does not support SF5 yet and has a dependency on the AdminBundle, so it will probably not support it for a while. I've removed it from dev-dependencies for now to check if the rest of the code works fine.

I am targeting this branch, because SF5 compatibility is required for this branch.

## Changelog

```markdown
### Added
- Symfony 5 support.
```

## To do

- [ ] Deal with UserBundle.
