### PR TITLE
Allow "symfony/intl:^5"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/dependency-injection": "^4.4",
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
-        "symfony/intl": "^4.4",
+        "symfony/intl": "^4.4 || ^5.0",
         "symfony/templating": "^4.4",
         "twig/twig": "^2.9"
     },

--- a/src/Templating/Helper/LocaleHelper.php
+++ b/src/Templating/Helper/LocaleHelper.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Templating\Helper;
 
 use Symfony\Component\Intl\Countries;
-use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Languages;
 use Symfony\Component\Intl\Locales;
 
@@ -33,13 +32,6 @@ class LocaleHelper extends BaseHelper
      */
     public function country($code, $locale = null)
     {
-        // NEXT_MAJOR: Remove this when dropping < 4.3 Symfony support
-        if (!class_exists(Countries::class)) {
-            $name = Intl::getRegionBundle()->getCountryName($code, $locale ?: $this->localeDetector->getLocale());
-
-            return $name ? $this->fixCharset($name) : '';
-        }
-
         return $this->fixCharset(Countries::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }
 
@@ -51,19 +43,6 @@ class LocaleHelper extends BaseHelper
      */
     public function language($code, $locale = null)
     {
-        // NEXT_MAJOR: Remove this when dropping < 4.3 Symfony support
-        if (!class_exists(Languages::class)) {
-            $codes = explode('_', $code);
-
-            $name = Intl::getLanguageBundle()->getLanguageName(
-                $codes[0],
-                $codes[1] ?? null,
-                $locale ?: $this->localeDetector->getLocale()
-            );
-
-            return $name ? $this->fixCharset($name) : '';
-        }
-
         return $this->fixCharset(Languages::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }
 
@@ -75,13 +54,6 @@ class LocaleHelper extends BaseHelper
      */
     public function locale($code, $locale = null)
     {
-        // NEXT_MAJOR: Remove this when dropping < 4.3 Symfony support
-        if (!class_exists(Locales::class)) {
-            $name = Intl::getLocaleBundle()->getLocaleName($code, $locale ?: $this->localeDetector->getLocale());
-
-            return $name ? $this->fixCharset($name) : '';
-        }
-
         return $this->fixCharset(Locales::getName($code, $locale ?: $this->localeDetector->getLocale()));
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow "symfony/intl:^5".
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #302, #305.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for "symfony/intl:^5".
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
