### PR TITLE
Add Symfony 5 and Twig 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,15 @@ matrix:
     - php: '7.3'
       env: SYMFONY='dev-master as 4.4.x-dev'
     - php: '7.3'
+      env: SONATA_USER=4.*
+    - php: '7.3'
+      env: SONATA_USER='dev-master as 4.x-dev'
+    - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
     - php: nightly
     - env: SYMFONY_DEPRECATIONS_HELPER=0
+    - env: SONATA_USER='dev-master as 4.x-dev'
     - env: SYMFONY='dev-master as 4.4.x-dev'
 
 before_install:

--- a/.travis/before_install_test.sh
+++ b/.travis/before_install_test.sh
@@ -9,3 +9,4 @@ echo "memory_limit=3072M" >> "$TRAVIS_INI_FILE"
 sed --in-place "s/\"dev-master\":/\"dev-${TRAVIS_COMMIT}\":/" composer.json
 
 if [ "$SYMFONY" != "" ]; then composer require "symfony/symfony:$SYMFONY" --no-update; fi;
+if [ "$SONATA_USER" != "" ]; then composer require "sonata-project/user-bundle:$SONATA_USER" --no-update; fi;

--- a/composer.json
+++ b/composer.json
@@ -22,23 +22,22 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "symfony/config": "^4.4",
-        "symfony/dependency-injection": "^4.4",
-        "symfony/http-foundation": "^4.4",
-        "symfony/http-kernel": "^4.4",
-        "symfony/intl": "^4.4 || ^5.0",
+        "php": "^7.2",
+        "symfony/config": "^4.4 || ^5.1",
+        "symfony/dependency-injection": "^4.4 || ^5.1",
+        "symfony/http-foundation": "^4.4 || ^5.1",
+        "symfony/http-kernel": "^4.4 || ^5.1",
+        "symfony/intl": "^4.4 || ^5.1",
         "symfony/templating": "^4.4",
-        "twig/twig": "^2.9"
+        "twig/twig": "^2.9 || ^3.0"
     },
     "conflict": {
-        "sonata-project/user-bundle": "<2.0 || >=5.0"
+        "sonata-project/user-bundle": "<3.6"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "sonata-project/user-bundle": "^3.6 || ^4.0",
         "symfony/phpunit-bridge": "^5.1",
-        "symfony/security-core": "^4.4"
+        "symfony/security-core": "^4.4 || ^5.1"
     },
     "config": {
         "sort-packages": true

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Class Sonata\\\\UserBundle\\\\Model\\\\User not found\\.$#"
+			count: 2
+			path: src/Timezone/UserBasedTimezoneDetector.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,6 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     level: 1
 
@@ -9,6 +12,3 @@ parameters:
     excludes_analyse:
         - src/Test/AbstractWidgetTestCase.php
         - tests/bootstrap.php
-
-    autoload_files:
-        - vendor/autoload.php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,13 +32,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('sonata_intl');
-
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->root('sonata_intl');
-        } else {
-            $rootNode = $treeBuilder->getRootNode();
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is needed to keep moving forward SonataAdminBundle major release and compat with Symfony 5.0.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #305 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for Symfony 5
- Added support for Twig 3
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
