### PR TITLE
Use get_admin_template twig function to get template

### DIFF
--- a/src/Resources/views/CRUD/list_currency.html.twig
+++ b/src/Resources/views/CRUD/list_currency.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field%}
     {%- if value is null -%}

--- a/src/Resources/views/CRUD/list_date.html.twig
+++ b/src/Resources/views/CRUD/list_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {%- include '@SonataIntl/CRUD/display_date.html.twig' -%}

--- a/src/Resources/views/CRUD/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/list_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
     {%- include '@SonataIntl/CRUD/display_datetime.html.twig' -%}

--- a/src/Resources/views/CRUD/list_decimal.html.twig
+++ b/src/Resources/views/CRUD/list_decimal.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field%}
     {%- if value is null -%}

--- a/src/Resources/views/CRUD/list_percent.html.twig
+++ b/src/Resources/views/CRUD/list_percent.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends admin.getTemplate('base_list_field') %}
+{% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field%}
     {%- if value is null -%}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Make the templates use the `get_admin_template` twig function to get the parent templates.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this function is supported since 4 years and does not break BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Use existing `get_admin_template` twig method to get parent templates

### Fixed
- Fixes compatibility with the 4.x branch of SonataAdminBundle
```
