### PR TITLE
Fix `NumberFormatter::format(): Argument #1 ($num) must be of type int|float, string given` (fixes #427)

### DIFF
--- a/src/Templating/Helper/BaseHelper.php
+++ b/src/Templating/Helper/BaseHelper.php
@@ -101,6 +101,8 @@ abstract class BaseHelper extends Helper
                 }
             }
         }
+
+        throw new \RuntimeException('Could not extract ICU data version information');
     }
 
     /**

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -358,10 +358,9 @@ class NumberHelper extends BaseHelper
             return $number;
         }
 
-        if (\is_numeric($number)) {
+        if (is_numeric($number)) {
             return (float) $number;
         }
-
 
         throw new \TypeError('Number must be either a float, an integer or a string');
     }

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -343,20 +343,22 @@ class NumberHelper extends BaseHelper
         return \constant($constantName);
     }
 
+    /**
+     * @param string|int|float $number
+     *
+     * @return int|float
+     **/
     private function parseNumericValue($number)
     {
-        if (!\is_scalar($number)) {
-            throw new \TypeError('Number must be a scalar value');
+        if (\is_float($number) || \is_int($number)) {
+            return $number;
         }
 
-        if (\is_string($number)) {
-            if (!\is_numeric($number)) {
-                throw new \typeError('Number must be a numeric string')
-            }
-
-            $number = (float) $number;
+        if (\is_numeric($number)) {
+            return (float) $number;
         }
 
-        return $number;
+
+        throw \TypeError('Number must be either a float, an integer or a string');
     }
 }

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -148,16 +148,12 @@ class NumberHelper extends BaseHelper
      */
     public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        // convert Doctrine's decimal type (fixed-point number represented as string) to float for backward compatibility
-        if (\is_string($number) && is_numeric($number)) {
-            $number = (float) $number;
-        }
-
         $methodArgs = array_pad(\func_get_args(), 6, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
 
         $formatter = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), \NumberFormatter::CURRENCY, $attributes, $textAttributes, $symbols);
+        $number = $this->parseNumericValue($number);
 
         return $this->fixCharset($formatter->formatCurrency($number, $currency));
     }
@@ -221,6 +217,7 @@ class NumberHelper extends BaseHelper
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
 
         $formatter = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), $style, $attributes, $textAttributes, $symbols);
+        $number = $this->parseNumericValue($number);
 
         return $this->fixCharset($formatter->format($number));
     }
@@ -344,5 +341,22 @@ class NumberHelper extends BaseHelper
         }
 
         return \constant($constantName);
+    }
+
+    private function parseNumericValue($number)
+    {
+        if (!\is_scalar($number)) {
+            throw new \TypeError('Number must be a scalar value');
+        }
+
+        if (\is_string($number)) {
+            if (!\is_numeric($number)) {
+                throw new \typeError('Number must be a numeric string')
+            }
+
+            $number = (float) $number;
+        }
+
+        return $number;
     }
 }

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -351,7 +351,7 @@ class NumberHelper extends BaseHelper
      * @param string|int|float $number
      *
      * @return int|float
-     **/
+     */
     private function parseNumericValue($number)
     {
         if (\is_float($number) || \is_int($number)) {
@@ -362,6 +362,6 @@ class NumberHelper extends BaseHelper
             return (float) $number;
         }
 
-        throw new \TypeError('Number must be either a float, an integer or a string');
+        throw new \TypeError('Number must be either a float, an integer or a numeric string');
     }
 }

--- a/src/Templating/Helper/NumberHelper.php
+++ b/src/Templating/Helper/NumberHelper.php
@@ -70,6 +70,7 @@ class NumberHelper extends BaseHelper
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+        $number = $this->parseNumericValue($number);
 
         return $this->format($number, \NumberFormatter::PERCENT, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -90,6 +91,7 @@ class NumberHelper extends BaseHelper
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+        $number = $this->parseNumericValue($number);
 
         return $this->format($number, \NumberFormatter::DURATION, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -110,6 +112,7 @@ class NumberHelper extends BaseHelper
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+        $number = $this->parseNumericValue($number);
 
         return $this->format($number, \NumberFormatter::DECIMAL, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -174,6 +177,7 @@ class NumberHelper extends BaseHelper
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+        $number = $this->parseNumericValue($number);
 
         return $this->format($number, \NumberFormatter::SCIENTIFIC, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -194,6 +198,7 @@ class NumberHelper extends BaseHelper
         $methodArgs = array_pad(\func_get_args(), 5, null);
 
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+        $number = $this->parseNumericValue($number);
 
         return $this->format($number, \NumberFormatter::ORDINAL, $attributes, $textAttributes, $symbols, $locale);
     }
@@ -217,7 +222,6 @@ class NumberHelper extends BaseHelper
         [$locale, $symbols] = $this->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
 
         $formatter = $this->getFormatter($locale ?: $this->localeDetector->getLocale(), $style, $attributes, $textAttributes, $symbols);
-        $number = $this->parseNumericValue($number);
 
         return $this->fixCharset($formatter->format($number));
     }
@@ -359,6 +363,6 @@ class NumberHelper extends BaseHelper
         }
 
 
-        throw \TypeError('Number must be either a float, an integer or a string');
+        throw new \TypeError('Number must be either a float, an integer or a string');
     }
 }

--- a/tests/Helper/NumberHelperTest.php
+++ b/tests/Helper/NumberHelperTest.php
@@ -31,10 +31,7 @@ class NumberHelperTest extends TestCase
         $this->assertSame('€10.49', $helper->formatCurrency(10.49, 'EUR'));
         $this->assertSame('€10.50', $helper->formatCurrency(10.499, 'EUR'));
         $this->assertSame('€10,000.50', $helper->formatCurrency(10000.499, 'EUR'));
-
-        // test compatibility with Doctrine's decimal type (fixed-point number represented as string)
         $this->assertSame('€10.49', $helper->formatCurrency('10.49', 'EUR'));
-
         $this->assertSame('€10', $helper->formatCurrency(10.49, 'EUR', [
             'fraction_digits' => 0,
         ]));
@@ -43,6 +40,7 @@ class NumberHelperTest extends TestCase
         $this->assertSame('10', $helper->formatDecimal(10));
         $this->assertSame('10.155', $helper->formatDecimal(10.15459));
         $this->assertSame('1,000,000.155', $helper->formatDecimal(1000000.15459));
+        $this->assertSame('1,000,000.155', $helper->formatDecimal('1000000.15459'));
 
         // scientific
         $this->assertSame('1E1', $helper->formatScientific(10));
@@ -50,6 +48,7 @@ class NumberHelperTest extends TestCase
         $this->assertSame('1.0001E3', $helper->formatScientific(1000.1));
         $this->assertSame('1.00000015459E6', $helper->formatScientific(1000000.15459));
         $this->assertSame('1.00000015459E6', $helper->formatScientific(1000000.15459));
+        $this->assertSame('1.00000015459E6', $helper->formatScientific('1000000.15459'));
 
         // duration
         $this->assertSame('277:46:40', $helper->formatDuration(1000000));
@@ -57,18 +56,19 @@ class NumberHelperTest extends TestCase
         // spell out
         $this->assertSame('one', $helper->formatSpellout(1));
         $this->assertSame('forty-two', $helper->formatSpellout(42));
-
         $this->assertSame('one million two hundred twenty-four thousand five hundred fifty-seven point one two five four', $helper->formatSpellout(1224557.1254));
 
         // percent
         $this->assertSame('10%', $helper->formatPercent(0.1));
         $this->assertSame('200%', $helper->formatPercent(1.999));
         $this->assertSame('99%', $helper->formatPercent(0.99));
+        $this->assertSame('99%', $helper->formatPercent('0.99'));
 
         // ordinal
         $this->assertSame('1st', $helper->formatOrdinal(1), 'ICU Version: '.NumberHelper::getICUDataVersion());
         $this->assertSame('100th', $helper->formatOrdinal(100), 'ICU Version: '.NumberHelper::getICUDataVersion());
         $this->assertSame('10,000th', $helper->formatOrdinal(10000), 'ICU Version: '.NumberHelper::getICUDataVersion());
+        $this->assertSame('10,000th', $helper->formatOrdinal('10000'), 'ICU Version: '.NumberHelper::getICUDataVersion());
     }
 
     public function testArguments()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #427.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed `NumberFormatter::format(): Argument #1 ($num) must be of type int|float, string given`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Update the tests;
