### PR TITLE
Use null as default value for the locale in order to be correctly replaced.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,11 +16,6 @@ parameters:
             path: tests/Timezone/UserBasedTimezoneDetectorTest.php
 
         - # NEXT_MAJOR: Remove this, UserBundle is not included as a dependency because it is only used on deprecated code.
-            message: "#^Parameter \\#1 \\$originalClassName of method PHPUnit\\\\Framework\\\\TestCase\\:\\:createMock\\(\\) expects class\\-string\\<Sonata\\\\UserBundle\\\\Model\\\\User\\>, string given\\.$#"
-            count: 1
-            path: tests/Timezone/UserBasedTimezoneDetectorTest.php
-
-        - # NEXT_MAJOR: Remove this, UserBundle is not included as a dependency because it is only used on deprecated code.
             message: "#^Trying to mock an undefined method getTimezone\\(\\) on class Sonata\\\\UserBundle\\\\Model\\\\User\\.$#"
             count: 1
             path: tests/Timezone/UserBasedTimezoneDetectorTest.php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,7 +40,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('locale')->defaultValue(false)->end()
+                ->scalarNode('locale')->defaultValue(null)->end()
                 ->arrayNode('timezone')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -37,7 +37,7 @@ class ConfigurationTest extends TestCase
                 'detectors' => [],
                 'locales' => [],
             ],
-            'locale' => false,
+            'locale' => null,
         ];
 
         static::assertSame($expected, $config);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Bugfix

Closes #487.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Correctly default to the kernel default locale when no locale is provided.
```