### PR TITLE
Prefix every filter with `sonata_` to avoid conflict

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,6 +1,19 @@
 UPGRADE 2.x
 ===========
 
+UPGRADE FROM 2.11 to 2.12
+=========================
+
+### Every twig filter is prefixed by `sonata_`
+
+- `format_date` is deprecated in favor of `sonata_format_date`.
+- `format_time` is deprecated in favor of `sonata_format_time`.
+- `format_datetime` is deprecated in favor of `sonata_format_datetime`.
+- `number_format_*` is deprecated in favor of `sonata_number_format_*`.
+- `country` is deprecated in favor of `sonata_country`.
+- `locale` is deprecated in favor of `sonata_locale`.
+- `language` is deprecated in favor of `sonata_language`.
+
 UPGRADE FROM 2.7 to 2.8
 =======================
 

--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -18,6 +18,6 @@ file that was distributed with this source code.
         {% set timezone = field_description.options.timezone|default(null) %}
         {% set dateType = field_description.options.dateType|default(null) %}
 
-        <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">{{ value | format_date(pattern, locale, timezone, dateType) }}</time>
+        <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">{{ value | sonata_format_date(pattern, locale, timezone, dateType) }}</time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -19,6 +19,6 @@ file that was distributed with this source code.
         {% set dateType = field_description.options.dateType|default(null) %}
         {% set timeType = field_description.options.timeType|default(null) %}
 
-        <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">{{ value | format_datetime(pattern, locale, timezone, dateType, timeType) }}</time>
+        <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">{{ value | sonata_format_datetime(pattern, locale, timezone, dateType, timeType) }}</time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/list_currency.html.twig
+++ b/src/Resources/views/CRUD/list_currency.html.twig
@@ -20,6 +20,6 @@ file that was distributed with this source code.
         {% set textAttributes = field_description.options.textAttributes|default({}) %}
         {% set locale = field_description.options.locale|default(null) %}
 
-        {{ value | number_format_currency(currency, attributes, textAttributes, locale) }}
+        {{ value | sonata_number_format_currency(currency, attributes, textAttributes, locale) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_decimal.html.twig
+++ b/src/Resources/views/CRUD/list_decimal.html.twig
@@ -19,6 +19,6 @@ file that was distributed with this source code.
         {% set textAttributes = field_description.options.textAttributes|default({}) %}
         {% set locale = field_description.options.locale|default(null) %}
 
-        {{ value | number_format_decimal(attributes, textAttributes, locale) }}
+        {{ value | sonata_number_format_decimal(attributes, textAttributes, locale) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_percent.html.twig
+++ b/src/Resources/views/CRUD/list_percent.html.twig
@@ -19,6 +19,6 @@ file that was distributed with this source code.
         {% set textAttributes = field_description.options.textAttributes|default({}) %}
         {% set locale = field_description.options.locale|default(null) %}
 
-        {{ value | number_format_percent(attributes, textAttributes, locale) }}
+        {{ value | sonata_number_format_percent(attributes, textAttributes, locale) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_currency.html.twig
+++ b/src/Resources/views/CRUD/show_currency.html.twig
@@ -20,6 +20,6 @@ file that was distributed with this source code.
         {% set textAttributes = field_description.options.textAttributes|default({}) %}
         {% set locale = field_description.options.locale|default(null) %}
 
-        {{ value | number_format_currency(currency, attributes, textAttributes, locale) }}
+        {{ value | sonata_number_format_currency(currency, attributes, textAttributes, locale) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_decimal.html.twig
+++ b/src/Resources/views/CRUD/show_decimal.html.twig
@@ -19,6 +19,6 @@ file that was distributed with this source code.
         {% set textAttributes = field_description.options.textAttributes|default({}) %}
         {% set locale = field_description.options.locale|default(null) %}
 
-        {{ value | number_format_decimal(attributes, textAttributes, locale) }}
+        {{ value | sonata_number_format_decimal(attributes, textAttributes, locale) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_percent.html.twig
+++ b/src/Resources/views/CRUD/show_percent.html.twig
@@ -19,6 +19,6 @@ file that was distributed with this source code.
         {% set textAttributes = field_description.options.textAttributes|default({}) %}
         {% set locale = field_description.options.locale|default(null) %}
 
-        {{ value | number_format_percent(attributes, textAttributes, locale) }}
+        {{ value | sonata_number_format_percent(attributes, textAttributes, locale) }}
     {%- endif -%}
 {% endblock %}

--- a/src/Twig/DateTimeRuntime.php
+++ b/src/Twig/DateTimeRuntime.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\IntlBundle\Twig;
+
+use Sonata\IntlBundle\Templating\Helper\DateTimeHelper;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class DateTimeRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var DateTimeHelper
+     */
+    private $helper;
+
+    public function __construct(DateTimeHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * @param \DateTime|string|int $date
+     * @param string|null          $pattern
+     * @param string|null          $locale
+     * @param string|null          $timezone
+     * @param int|null             $dateType
+     *
+     * @return string
+     */
+    public function formatDate($date, $pattern = null, $locale = null, $timezone = null, $dateType = null)
+    {
+        if (null !== $pattern) {
+            return $this->helper->format($date, $pattern, $locale, $timezone);
+        }
+
+        return $this->helper->formatDate($date, $locale, $timezone, $dateType);
+    }
+
+    /**
+     * @param \DateTime|string|int $time
+     * @param string|null          $pattern
+     * @param string|null          $locale
+     * @param string|null          $timezone
+     * @param int|null             $timeType
+     *
+     * @return string
+     */
+    public function formatTime($time, $pattern = null, $locale = null, $timezone = null, $timeType = null)
+    {
+        if (null !== $pattern) {
+            return $this->helper->format($time, $pattern, $locale, $timezone);
+        }
+
+        return $this->helper->formatTime($time, $locale, $timezone, $timeType);
+    }
+
+    /**
+     * @param \DateTime|string|int $time
+     * @param string|null          $pattern
+     * @param string|null          $locale
+     * @param string|null          $timezone
+     * @param int|null             $dateType
+     * @param int|null             $timeType
+     *
+     * @return string
+     */
+    public function formatDatetime($time, $pattern = null, $locale = null, $timezone = null, $dateType = null, $timeType = null)
+    {
+        if (null !== $pattern) {
+            return $this->helper->format($time, $pattern, $locale, $timezone);
+        }
+
+        return $this->helper->formatDateTime($time, $locale, $timezone, $dateType, $timeType);
+    }
+}

--- a/src/Twig/Extension/DateTimeExtension.php
+++ b/src/Twig/Extension/DateTimeExtension.php
@@ -51,11 +51,11 @@ class DateTimeExtension extends AbstractExtension
     {
         return [
             new TwigFilter('format_date', [$this, 'formatDate'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_format_date', [$this, 'formatDate'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_format_date', [DateTimeRuntime::class, 'formatDate'], ['is_safe' => ['html']]),
             new TwigFilter('format_time', [$this, 'formatTime'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_format_time', [$this, 'formatTime'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_format_time', [DateTimeRuntime::class, 'formatTime'], ['is_safe' => ['html']]),
             new TwigFilter('format_datetime', [$this, 'formatDatetime'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_format_datetime', [$this, 'formatDatetime'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_format_datetime', [DateTimeRuntime::class, 'formatDatetime'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/Extension/DateTimeExtension.php
+++ b/src/Twig/Extension/DateTimeExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Twig\Extension;
 
 use Sonata\IntlBundle\Templating\Helper\DateTimeHelper;
+use Sonata\IntlBundle\Twig\DateTimeRuntime;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
@@ -29,9 +30,18 @@ class DateTimeExtension extends AbstractExtension
      */
     protected $helper;
 
+    /**
+     * @var DateTimeRuntime
+     */
+    private $dateTimeRuntime;
+
+    /**
+     * NEXT_MAJOR: Remove this constructor.
+     */
     public function __construct(DateTimeHelper $helper)
     {
         $this->helper = $helper;
+        $this->dateTimeRuntime = new DateTimeRuntime($helper);
     }
 
     /**
@@ -50,6 +60,8 @@ class DateTimeExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param \DateTime|string|int $date
      * @param string|null          $pattern
      * @param string|null          $locale
@@ -60,14 +72,20 @@ class DateTimeExtension extends AbstractExtension
      */
     public function formatDate($date, $pattern = null, $locale = null, $timezone = null, $dateType = null)
     {
-        if (null !== $pattern) {
-            return $this->helper->format($date, $pattern, $locale, $timezone);
-        }
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            DateTimeRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        return $this->helper->formatDate($date, $locale, $timezone, $dateType);
+        return $this->dateTimeRuntime->formatDate($date, $pattern, $locale, $timezone, $dateType);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param \DateTime|string|int $time
      * @param string|null          $pattern
      * @param string|null          $locale
@@ -78,14 +96,20 @@ class DateTimeExtension extends AbstractExtension
      */
     public function formatTime($time, $pattern = null, $locale = null, $timezone = null, $timeType = null)
     {
-        if (null !== $pattern) {
-            return $this->helper->format($time, $pattern, $locale, $timezone);
-        }
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            DateTimeRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        return $this->helper->formatTime($time, $locale, $timezone, $timeType);
+        return $this->dateTimeRuntime->formatTime($time, $pattern, $locale, $timezone, $timeType);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param \DateTime|string|int $time
      * @param string|null          $pattern
      * @param string|null          $locale
@@ -97,11 +121,15 @@ class DateTimeExtension extends AbstractExtension
      */
     public function formatDatetime($time, $pattern = null, $locale = null, $timezone = null, $dateType = null, $timeType = null)
     {
-        if (null !== $pattern) {
-            return $this->helper->format($time, $pattern, $locale, $timezone);
-        }
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            DateTimeRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        return $this->helper->formatDateTime($time, $locale, $timezone, $dateType, $timeType);
+        return $this->dateTimeRuntime->formatDatetime($time, $pattern, $locale, $timezone, $timeType);
     }
 
     /**

--- a/src/Twig/Extension/DateTimeExtension.php
+++ b/src/Twig/Extension/DateTimeExtension.php
@@ -40,9 +40,12 @@ class DateTimeExtension extends AbstractExtension
     public function getFilters()
     {
         return [
-            new TwigFilter('format_date', [$this, 'formatDate'], ['is_safe' => ['html']]),
-            new TwigFilter('format_time', [$this, 'formatTime'], ['is_safe' => ['html']]),
-            new TwigFilter('format_datetime', [$this, 'formatDatetime'], ['is_safe' => ['html']]),
+            new TwigFilter('format_date', [$this, 'formatDate'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_format_date', [$this, 'formatDate'], ['is_safe' => ['html']]),
+            new TwigFilter('format_time', [$this, 'formatTime'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_format_time', [$this, 'formatTime'], ['is_safe' => ['html']]),
+            new TwigFilter('format_datetime', [$this, 'formatDatetime'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_format_datetime', [$this, 'formatDatetime'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/Extension/DateTimeExtension.php
+++ b/src/Twig/Extension/DateTimeExtension.php
@@ -72,13 +72,11 @@ class DateTimeExtension extends AbstractExtension
      */
     public function formatDate($date, $pattern = null, $locale = null, $timezone = null, $dateType = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            DateTimeRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The format_date filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_format_date instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->dateTimeRuntime->formatDate($date, $pattern, $locale, $timezone, $dateType);
     }
@@ -96,13 +94,11 @@ class DateTimeExtension extends AbstractExtension
      */
     public function formatTime($time, $pattern = null, $locale = null, $timezone = null, $timeType = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            DateTimeRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The format_time filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_format_time instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->dateTimeRuntime->formatTime($time, $pattern, $locale, $timezone, $timeType);
     }
@@ -121,13 +117,11 @@ class DateTimeExtension extends AbstractExtension
      */
     public function formatDatetime($time, $pattern = null, $locale = null, $timezone = null, $dateType = null, $timeType = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            DateTimeRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The format_date_time filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_format_date_time instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->dateTimeRuntime->formatDatetime($time, $pattern, $locale, $timezone, $timeType);
     }

--- a/src/Twig/Extension/LocaleExtension.php
+++ b/src/Twig/Extension/LocaleExtension.php
@@ -51,11 +51,11 @@ class LocaleExtension extends AbstractExtension
     {
         return [
             new TwigFilter('country', [$this, 'country'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_country', [$this, 'country'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_country', [LocaleRuntime::class, 'country'], ['is_safe' => ['html']]),
             new TwigFilter('locale', [$this, 'locale'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_locale', [$this, 'locale'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_locale', [LocaleRuntime::class, 'locale'], ['is_safe' => ['html']]),
             new TwigFilter('language', [$this, 'language'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_language', [$this, 'language'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_language', [LocaleRuntime::class, 'language'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/Extension/LocaleExtension.php
+++ b/src/Twig/Extension/LocaleExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Twig\Extension;
 
 use Sonata\IntlBundle\Templating\Helper\LocaleHelper;
+use Sonata\IntlBundle\Twig\LocaleRuntime;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
@@ -29,9 +30,18 @@ class LocaleExtension extends AbstractExtension
      */
     protected $helper;
 
+    /**
+     * @var LocaleRuntime
+     */
+    private $localeRuntime;
+
+    /**
+     * NEXT_MAJOR: Remove this constructor.
+     */
     public function __construct(LocaleHelper $helper)
     {
         $this->helper = $helper;
+        $this->localeRuntime = new LocaleRuntime($this->helper);
     }
 
     /**
@@ -50,6 +60,8 @@ class LocaleExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Returns the localized country name from the provided code.
      *
      * @param string      $code
@@ -59,10 +71,20 @@ class LocaleExtension extends AbstractExtension
      */
     public function country($code, $locale = null)
     {
-        return $this->helper->country($code, $locale);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            LocaleRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
+
+        return $this->localeRuntime->country($code, $locale);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Returns the localized locale name from the provided code.
      *
      * @param string      $code
@@ -72,10 +94,20 @@ class LocaleExtension extends AbstractExtension
      */
     public function locale($code, $locale = null)
     {
-        return $this->helper->locale($code, $locale);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            LocaleRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
+
+        return $this->localeRuntime->locale($code, $locale);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Returns the localized language name from the provided code.
      *
      * @param string      $code
@@ -85,7 +117,15 @@ class LocaleExtension extends AbstractExtension
      */
     public function language($code, $locale = null)
     {
-        return $this->helper->language($code, $locale);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            LocaleRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
+
+        return $this->localeRuntime->language($code, $locale);
     }
 
     /**

--- a/src/Twig/Extension/LocaleExtension.php
+++ b/src/Twig/Extension/LocaleExtension.php
@@ -71,13 +71,11 @@ class LocaleExtension extends AbstractExtension
      */
     public function country($code, $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            LocaleRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The country filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_country instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->localeRuntime->country($code, $locale);
     }
@@ -94,13 +92,11 @@ class LocaleExtension extends AbstractExtension
      */
     public function locale($code, $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            LocaleRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The locale filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_locale instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->localeRuntime->locale($code, $locale);
     }
@@ -117,13 +113,11 @@ class LocaleExtension extends AbstractExtension
      */
     public function language($code, $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            LocaleRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The language filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_language instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->localeRuntime->language($code, $locale);
     }

--- a/src/Twig/Extension/LocaleExtension.php
+++ b/src/Twig/Extension/LocaleExtension.php
@@ -40,9 +40,12 @@ class LocaleExtension extends AbstractExtension
     public function getFilters()
     {
         return [
-            new TwigFilter('country', [$this, 'country'], ['is_safe' => ['html']]),
-            new TwigFilter('locale', [$this, 'locale'], ['is_safe' => ['html']]),
-            new TwigFilter('language', [$this, 'language'], ['is_safe' => ['html']]),
+            new TwigFilter('country', [$this, 'country'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_country', [$this, 'country'], ['is_safe' => ['html']]),
+            new TwigFilter('locale', [$this, 'locale'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_locale', [$this, 'locale'], ['is_safe' => ['html']]),
+            new TwigFilter('language', [$this, 'language'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_language', [$this, 'language'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/Extension/NumberExtension.php
+++ b/src/Twig/Extension/NumberExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\IntlBundle\Twig\Extension;
 
 use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Sonata\IntlBundle\Twig\NumberRuntime;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
@@ -32,11 +33,17 @@ class NumberExtension extends AbstractExtension
     protected $helper;
 
     /**
-     * @param NumberHelper $helper A NumberHelper helper instance
+     * @var NumberRuntime
+     */
+    private $numberRuntime;
+
+    /**
+     * NEXT_MAJOR: Remove this constructor.
      */
     public function __construct(NumberHelper $helper)
     {
         $this->helper = $helper;
+        $this->numberRuntime = new NumberRuntime($this->helper);
     }
 
     /**
@@ -73,6 +80,8 @@ class NumberExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Formats a number as currency according to the specified locale and
      * \NumberFormatter attributes.
      *
@@ -86,14 +95,20 @@ class NumberExtension extends AbstractExtension
      */
     public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        $methodArgs = array_pad(\func_get_args(), 6, null);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            NumberRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
-
-        return $this->helper->formatCurrency($number, $currency, $attributes, $textAttributes, $symbols, $locale);
+        return $this->numberRuntime->formatCurrency(...\func_get_args());
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Formats a number as decimal according to the specified locale and
      * \NumberFormatter attributes.
      *
@@ -106,14 +121,20 @@ class NumberExtension extends AbstractExtension
      */
     public function formatDecimal($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        $methodArgs = array_pad(\func_get_args(), 5, null);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            NumberRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
-
-        return $this->helper->formatDecimal($number, $attributes, $textAttributes, $symbols, $locale);
+        return $this->numberRuntime->formatDecimal(...\func_get_args());
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Formats a number in scientific notation according to the specified
      * locale and \NumberFormatter attributes.
      *
@@ -126,14 +147,20 @@ class NumberExtension extends AbstractExtension
      */
     public function formatScientific($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        $methodArgs = array_pad(\func_get_args(), 5, null);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            NumberRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
-
-        return $this->helper->formatScientific($number, $attributes, $textAttributes, $symbols, $locale);
+        return $this->numberRuntime->formatScientific(...\func_get_args());
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Formats a number as spellout according to the specified locale and
      * \NumberFormatter attributes.
      *
@@ -146,14 +173,20 @@ class NumberExtension extends AbstractExtension
      */
     public function formatSpellout($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        $methodArgs = array_pad(\func_get_args(), 5, null);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            NumberRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
-
-        return $this->helper->formatSpellout($number, $attributes, $textAttributes, $symbols, $locale);
+        return $this->numberRuntime->formatSpellout(...\func_get_args());
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Formats a number as percent according to the specified locale and
      * \NumberFormatter attributes.
      *
@@ -166,14 +199,20 @@ class NumberExtension extends AbstractExtension
      */
     public function formatPercent($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        $methodArgs = array_pad(\func_get_args(), 5, null);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            NumberRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
-
-        return $this->helper->formatPercent($number, $attributes, $textAttributes, $symbols, $locale);
+        return $this->numberRuntime->formatPercent(...\func_get_args());
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Formats a number as duration according to the specified locale and
      * \NumberFormatter attributes.
      *
@@ -186,14 +225,20 @@ class NumberExtension extends AbstractExtension
      */
     public function formatDuration($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        $methodArgs = array_pad(\func_get_args(), 5, null);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            NumberRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
-
-        return $this->helper->formatDuration($number, $attributes, $textAttributes, $symbols, $locale);
+        return $this->numberRuntime->formatDuration(...\func_get_args());
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * Formats a number as ordinal according to the specified locale and
      * \NumberFormatter attributes.
      *
@@ -206,10 +251,14 @@ class NumberExtension extends AbstractExtension
      */
     public function formatOrdinal($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        $methodArgs = array_pad(\func_get_args(), 5, null);
+        @trigger_error(sprintf(
+            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
+            'Use %s::%s instead.',
+            __METHOD__,
+            NumberRuntime::class,
+            __METHOD__,
+        ), \E_USER_DEPRECATED);
 
-        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
-
-        return $this->helper->formatOrdinal($number, $attributes, $textAttributes, $symbols, $locale);
+        return $this->numberRuntime->formatOrdinal(...\func_get_args());
     }
 }

--- a/src/Twig/Extension/NumberExtension.php
+++ b/src/Twig/Extension/NumberExtension.php
@@ -95,13 +95,11 @@ class NumberExtension extends AbstractExtension
      */
     public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            NumberRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The number_format_currency filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_number_format_currency instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->numberRuntime->formatCurrency(...\func_get_args());
     }
@@ -121,13 +119,11 @@ class NumberExtension extends AbstractExtension
      */
     public function formatDecimal($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            NumberRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The number_format_decimal filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_number_format_decimal instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->numberRuntime->formatDecimal(...\func_get_args());
     }
@@ -147,13 +143,11 @@ class NumberExtension extends AbstractExtension
      */
     public function formatScientific($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            NumberRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The number_format_scientific filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_number_format_decimal instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->numberRuntime->formatScientific(...\func_get_args());
     }
@@ -173,13 +167,11 @@ class NumberExtension extends AbstractExtension
      */
     public function formatSpellout($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            NumberRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The number_format_spellout filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_number_format_spellout instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->numberRuntime->formatSpellout(...\func_get_args());
     }
@@ -199,13 +191,11 @@ class NumberExtension extends AbstractExtension
      */
     public function formatPercent($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            NumberRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The number_format_percent filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_number_format_percent instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->numberRuntime->formatPercent(...\func_get_args());
     }
@@ -225,13 +215,11 @@ class NumberExtension extends AbstractExtension
      */
     public function formatDuration($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            NumberRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The number_format_duration filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_number_format_duration instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->numberRuntime->formatDuration(...\func_get_args());
     }
@@ -251,13 +239,11 @@ class NumberExtension extends AbstractExtension
      */
     public function formatOrdinal($number, array $attributes = [], array $textAttributes = [], $locale = null)
     {
-        @trigger_error(sprintf(
-            'The %s method is deprecated since 2.x and will be removed on 3.0. '.
-            'Use %s::%s instead.',
-            __METHOD__,
-            NumberRuntime::class,
-            __METHOD__,
-        ), \E_USER_DEPRECATED);
+        @trigger_error(
+            'The number_format_ordinal filter is deprecated since 2.x and will be removed on 3.0. '.
+            'Use sonata_number_format_ordinal instead.',
+            \E_USER_DEPRECATED
+        );
 
         return $this->numberRuntime->formatOrdinal(...\func_get_args());
     }

--- a/src/Twig/Extension/NumberExtension.php
+++ b/src/Twig/Extension/NumberExtension.php
@@ -45,13 +45,20 @@ class NumberExtension extends AbstractExtension
     public function getFilters()
     {
         return [
-            new TwigFilter('number_format_currency', [$this, 'formatCurrency'], ['is_safe' => ['html']]),
-            new TwigFilter('number_format_decimal', [$this, 'formatDecimal'], ['is_safe' => ['html']]),
-            new TwigFilter('number_format_scientific', [$this, 'formatScientific'], ['is_safe' => ['html']]),
-            new TwigFilter('number_format_spellout', [$this, 'formatSpellout'], ['is_safe' => ['html']]),
-            new TwigFilter('number_format_percent', [$this, 'formatPercent'], ['is_safe' => ['html']]),
-            new TwigFilter('number_format_duration', [$this, 'formatDuration'], ['is_safe' => ['html']]),
-            new TwigFilter('number_format_ordinal', [$this, 'formatOrdinal'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_currency', [$this, 'formatCurrency'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_number_format_currency', [$this, 'formatCurrency'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_decimal', [$this, 'formatDecimal'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_number_format_decimal', [$this, 'formatDecimal'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_scientific', [$this, 'formatScientific'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_number_format_scientific', [$this, 'formatScientific'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_spellout', [$this, 'formatSpellout'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_number_format_spellout', [$this, 'formatSpellout'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_percent', [$this, 'formatPercent'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_number_format_percent', [$this, 'formatPercent'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_duration', [$this, 'formatDuration'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_number_format_duration', [$this, 'formatDuration'], ['is_safe' => ['html']]),
+            new TwigFilter('number_format_ordinal', [$this, 'formatOrdinal'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
+            new TwigFilter('sonata_number_format_ordinal', [$this, 'formatOrdinal'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/Extension/NumberExtension.php
+++ b/src/Twig/Extension/NumberExtension.php
@@ -53,19 +53,19 @@ class NumberExtension extends AbstractExtension
     {
         return [
             new TwigFilter('number_format_currency', [$this, 'formatCurrency'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_number_format_currency', [$this, 'formatCurrency'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_number_format_currency', [NumberRuntime::class, 'formatCurrency'], ['is_safe' => ['html']]),
             new TwigFilter('number_format_decimal', [$this, 'formatDecimal'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_number_format_decimal', [$this, 'formatDecimal'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_number_format_decimal', [NumberRuntime::class, 'formatDecimal'], ['is_safe' => ['html']]),
             new TwigFilter('number_format_scientific', [$this, 'formatScientific'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_number_format_scientific', [$this, 'formatScientific'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_number_format_scientific', [NumberRuntime::class, 'formatScientific'], ['is_safe' => ['html']]),
             new TwigFilter('number_format_spellout', [$this, 'formatSpellout'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_number_format_spellout', [$this, 'formatSpellout'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_number_format_spellout', [NumberRuntime::class, 'formatSpellout'], ['is_safe' => ['html']]),
             new TwigFilter('number_format_percent', [$this, 'formatPercent'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_number_format_percent', [$this, 'formatPercent'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_number_format_percent', [NumberRuntime::class, 'formatPercent'], ['is_safe' => ['html']]),
             new TwigFilter('number_format_duration', [$this, 'formatDuration'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_number_format_duration', [$this, 'formatDuration'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_number_format_duration', [NumberRuntime::class, 'formatDuration'], ['is_safe' => ['html']]),
             new TwigFilter('number_format_ordinal', [$this, 'formatOrdinal'], ['is_safe' => ['html']]), // NEXT_MAJOR: Remove this line
-            new TwigFilter('sonata_number_format_ordinal', [$this, 'formatOrdinal'], ['is_safe' => ['html']]),
+            new TwigFilter('sonata_number_format_ordinal', [NumberRuntime::class, 'formatOrdinal'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/LocaleRuntime.php
+++ b/src/Twig/LocaleRuntime.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\IntlBundle\Twig;
+
+use Sonata\IntlBundle\Templating\Helper\LocaleHelper;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class LocaleRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var LocaleHelper
+     */
+    private $helper;
+
+    public function __construct(LocaleHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * Returns the localized country name from the provided code.
+     *
+     * @param string      $code
+     * @param string|null $locale
+     *
+     * @return string
+     */
+    public function country($code, $locale = null)
+    {
+        return $this->helper->country($code, $locale);
+    }
+
+    /**
+     * Returns the localized locale name from the provided code.
+     *
+     * @param string      $code
+     * @param string|null $locale
+     *
+     * @return string
+     */
+    public function locale($code, $locale = null)
+    {
+        return $this->helper->locale($code, $locale);
+    }
+
+    /**
+     * Returns the localized language name from the provided code.
+     *
+     * @param string      $code
+     * @param string|null $locale
+     *
+     * @return string
+     */
+    public function language($code, $locale = null)
+    {
+        return $this->helper->language($code, $locale);
+    }
+}

--- a/src/Twig/NumberRuntime.php
+++ b/src/Twig/NumberRuntime.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\IntlBundle\Twig;
+
+use Sonata\IntlBundle\Templating\Helper\NumberHelper;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class NumberRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var NumberHelper The instance of the NumberHelper helper
+     */
+    private $helper;
+
+    /**
+     * @param NumberHelper $helper A NumberHelper helper instance
+     */
+    public function __construct(NumberHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * Formats a number as currency according to the specified locale and
+     * \NumberFormatter attributes.
+     *
+     * @param string|float|int $number         The number to format
+     * @param string           $currency       The currency in which format the number
+     * @param array            $attributes     The attributes used by \NumberFormatter
+     * @param array            $textAttributes The text attributes used by \NumberFormatter
+     * @param string|null      $locale         The locale used to format the number
+     *
+     * @return string The formatted number
+     */
+    public function formatCurrency($number, $currency, array $attributes = [], array $textAttributes = [], $locale = null)
+    {
+        $methodArgs = array_pad(\func_get_args(), 6, null);
+
+        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[4], $methodArgs[5]);
+
+        return $this->helper->formatCurrency($number, $currency, $attributes, $textAttributes, $symbols, $locale);
+    }
+
+    /**
+     * Formats a number as decimal according to the specified locale and
+     * \NumberFormatter attributes.
+     *
+     * @param string|float|int $number         The number to format
+     * @param array            $attributes     The attributes used by \NumberFormatter
+     * @param array            $textAttributes The text attributes used by \NumberFormatter
+     * @param string|null      $locale         The locale used to format the number
+     *
+     * @return string The formatted number
+     */
+    public function formatDecimal($number, array $attributes = [], array $textAttributes = [], $locale = null)
+    {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
+        return $this->helper->formatDecimal($number, $attributes, $textAttributes, $symbols, $locale);
+    }
+
+    /**
+     * Formats a number in scientific notation according to the specified
+     * locale and \NumberFormatter attributes.
+     *
+     * @param string|float|int $number         The number to format
+     * @param array            $attributes     The attributes used by \NumberFormatter
+     * @param array            $textAttributes The text attributes used by \NumberFormatter
+     * @param string|null      $locale         The locale used to format the number
+     *
+     * @return string The formatted number
+     */
+    public function formatScientific($number, array $attributes = [], array $textAttributes = [], $locale = null)
+    {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
+        return $this->helper->formatScientific($number, $attributes, $textAttributes, $symbols, $locale);
+    }
+
+    /**
+     * Formats a number as spellout according to the specified locale and
+     * \NumberFormatter attributes.
+     *
+     * @param string|float|int $number         The number to format
+     * @param array            $attributes     The attributes used by \NumberFormatter
+     * @param array            $textAttributes The text attributes used by \NumberFormatter
+     * @param string|null      $locale         The locale used to format the number
+     *
+     * @return string The formatted number
+     */
+    public function formatSpellout($number, array $attributes = [], array $textAttributes = [], $locale = null)
+    {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
+        return $this->helper->formatSpellout($number, $attributes, $textAttributes, $symbols, $locale);
+    }
+
+    /**
+     * Formats a number as percent according to the specified locale and
+     * \NumberFormatter attributes.
+     *
+     * @param string|float|int $number         The number to format
+     * @param array            $attributes     The attributes used by \NumberFormatter
+     * @param array            $textAttributes The text attributes used by \NumberFormatter
+     * @param string|null      $locale         The locale used to format the number
+     *
+     * @return string The formatted number
+     */
+    public function formatPercent($number, array $attributes = [], array $textAttributes = [], $locale = null)
+    {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
+        return $this->helper->formatPercent($number, $attributes, $textAttributes, $symbols, $locale);
+    }
+
+    /**
+     * Formats a number as duration according to the specified locale and
+     * \NumberFormatter attributes.
+     *
+     * @param string|float|int $number         The number to format
+     * @param array            $attributes     The attributes used by \NumberFormatter
+     * @param array            $textAttributes The text attributes used by \NumberFormatter
+     * @param string|null      $locale         The locale used to format the number
+     *
+     * @return string The formatted number
+     */
+    public function formatDuration($number, array $attributes = [], array $textAttributes = [], $locale = null)
+    {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
+        return $this->helper->formatDuration($number, $attributes, $textAttributes, $symbols, $locale);
+    }
+
+    /**
+     * Formats a number as ordinal according to the specified locale and
+     * \NumberFormatter attributes.
+     *
+     * @param string|float|int $number         The number to format
+     * @param array            $attributes     The attributes used by \NumberFormatter
+     * @param array            $textAttributes The text attributes used by \NumberFormatter
+     * @param string|null      $locale         The locale used to format the number
+     *
+     * @return string The formatted number
+     */
+    public function formatOrdinal($number, array $attributes = [], array $textAttributes = [], $locale = null)
+    {
+        $methodArgs = array_pad(\func_get_args(), 5, null);
+
+        [$locale, $symbols] = $this->helper->normalizeMethodSignature($methodArgs[3], $methodArgs[4]);
+
+        return $this->helper->formatOrdinal($number, $attributes, $textAttributes, $symbols, $locale);
+    }
+}

--- a/tests/Twig/Extension/NumberExtensionTest.php
+++ b/tests/Twig/Extension/NumberExtensionTest.php
@@ -24,6 +24,8 @@ use Sonata\IntlBundle\Twig\Extension\NumberExtension;
 class NumberExtensionTest extends TestCase
 {
     /**
+     * @group legacy
+     *
      * @dataProvider provideFormatArguments
      */
     public function testFormat($methodName, $testData)
@@ -145,6 +147,9 @@ class NumberExtensionTest extends TestCase
         ];
     }
 
+    /**
+     * @group legacy
+     */
     public function testFormatOrdinal()
     {
         $localeDetector = $this->createLocaleDetectorMock();
@@ -156,6 +161,9 @@ class NumberExtensionTest extends TestCase
         static::assertSame('10,000th', $extension->formatOrdinal(10000), 'ICU Version: '.NumberHelper::getICUDataVersion());
     }
 
+    /**
+     * @group legacy
+     */
     public function testFormatSpellout()
     {
         $localeDetector = $this->createLocaleDetectorMock();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I am targeting this branch, because minor.

This might be annoying to have a `sonata_` prefix, but I don't see an other way to be sure to avoid a conflict with either `twigIntl` or another library.

Closes #299.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
-`sonata_format_date` filter
-`sonata_format_time` filter
-`sonata_format_datetime` filter
-`sonata_number_format_*` filters
-`sonata_country` filter
-`sonata_locale` filter
-`sonata_language` filter

### Deprecated
-`format_date` filter
-`format_time` filter
-`format_datetime` filter
-`number_format_*` filters
-`country` filter
-`locale` filter
-`language` filter
```