### PR TITLE
Drop support of Symfony 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "homepage": "https://docs.sonata-project.org/projects/SonataIntlBundle",
     "require": {
         "php": "^7.3 || ^8.0",
-        "symfony/config": "^4.4 || ^5.3 || ^6.0",
-        "symfony/dependency-injection": "^4.4.8 || ^5.3 || ^6.0",
-        "symfony/http-foundation": "^4.4 || ^5.3 || ^6.0",
-        "symfony/http-kernel": "^4.4.13 || ^5.3 || ^6.0",
-        "symfony/intl": "^4.4 || ^5.3 || ^6.0",
-        "symfony/templating": "^4.4 || ^5.3 || ^6.0",
+        "symfony/config": "^4.4 || ^5.4 || ^6.0",
+        "symfony/dependency-injection": "^4.4.8 || ^5.4 || ^6.0",
+        "symfony/http-foundation": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-kernel": "^4.4.13 || ^5.4 || ^6.0",
+        "symfony/intl": "^4.4 || ^5.4 || ^6.0",
+        "symfony/templating": "^4.4 || ^5.4 || ^6.0",
         "twig/twig": "^2.9 || ^3.0"
     },
     "require-dev": {
@@ -43,8 +43,8 @@
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
-        "symfony/phpunit-bridge": "^6.0",
-        "symfony/security-core": "^4.4.23 || ^5.3 || ^6.0",
+        "symfony/phpunit-bridge": "^6.1",
+        "symfony/security-core": "^4.4.23 || ^5.4 || ^6.0",
         "vimeo/psalm": "^4.7.2"
     },
     "conflict": {


### PR DESCRIPTION
## Subject

Support only maintained versions of Symfony

I am targeting this branch, because these changes are BC.

## Changelog

```markdown
### Removed
- Support of Symfony 5.3
```