### PR TITLE
Update NumberRuntime to use NumberFormatterInterface

### DIFF
--- a/src/Twig/NumberRuntime.php
+++ b/src/Twig/NumberRuntime.php
@@ -13,29 +13,29 @@ declare(strict_types=1);
 
 namespace Sonata\IntlBundle\Twig;
 
-use Sonata\IntlBundle\Helper\NumberFormatter;
+use Sonata\IntlBundle\Helper\NumberFormatterInterface;
 use Sonata\IntlBundle\Templating\Helper\NumberHelper as TemplatingNumberHelper;
 use Twig\Extension\RuntimeExtensionInterface;
 
 final class NumberRuntime implements RuntimeExtensionInterface
 {
     /**
-     * @var NumberFormatter|TemplatingNumberHelper The instance of the NumberHelper helper
+     * @var NumberFormatterInterface|TemplatingNumberHelper The instance of the NumberHelper helper
      */
     private $helper;
 
     /**
-     * @param NumberFormatter|TemplatingNumberHelper $helper A NumberHelper helper instance
+     * @param NumberFormatterInterface|TemplatingNumberHelper $helper A NumberHelper helper instance
      */
     public function __construct(object $helper)
     {
         if ($helper instanceof TemplatingNumberHelper) {
             @trigger_error(
-                sprintf('The use of %s is deprecated since 2.13, use %s instead.', TemplatingNumberHelper::class, NumberFormatter::class),
+                sprintf('The use of %s is deprecated since 2.13, use %s instead.', TemplatingNumberHelper::class, NumberFormatterInterface::class),
                 \E_USER_DEPRECATED
             );
-        } elseif (!$helper instanceof NumberFormatter) {
-            throw new \TypeError(sprintf('Helper must be an instanceof %s, instanceof %s given', NumberFormatter::class, \get_class($helper)));
+        } elseif (!$helper instanceof NumberFormatterInterface) {
+            throw new \TypeError(sprintf('Helper must be an instanceof %s, instanceof %s given', NumberFormatterInterface::class, \get_class($helper)));
         }
         $this->helper = $helper;
     }


### PR DESCRIPTION
i somehow missed that one place where i wanted to use NumberFormatterInterface instead

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.
