### PR TITLE
fix: Add missing kernel.local_aware tags for definitions that impleme…

### DIFF
--- a/src/Resources/config/intl.php
+++ b/src/Resources/config/intl.php
@@ -74,18 +74,21 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.intl.helper.locale', '%sonata.intl.helper.locale.class%')
             ->public()
+            ->tag('kernel.locale_aware')
             ->args([
                 '%kernel.charset%',
             ])
 
         ->set('sonata.intl.helper.number', '%sonata.intl.helper.number.class%')
             ->public()
+            ->tag('kernel.locale_aware')
             ->args([
                 '%kernel.charset%',
             ])
 
         ->set('sonata.intl.helper.datetime', '%sonata.intl.helper.datetime.class%')
             ->public()
+            ->tag('kernel.locale_aware')
             ->args([
                 new ReferenceConfigurator('sonata.intl.timezone_detector'),
                 '%kernel.charset%',
@@ -164,6 +167,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata_intl.timezone_detector', [
                 'alias' => 'locale_aware',
             ])
+            ->tag('kernel.locale_aware')
             ->args([
                 '',
             ]);


### PR DESCRIPTION
…nt the LocaleAwareInterface

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixes the issue described in #541 

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the problem appeared with version 2.13.0.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #541 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Add missing kernel.local_aware dependency injection container tags for definitions that implement symfony's LocaleAwareInterface.
```
