### PR TITLE
Fix PHPStan findings at `UserBasedTimezoneDetectorTest::testUserTimezoneDetection()`

### DIFF
--- a/tests/Timezone/UserBasedTimezoneDetectorTest.php
+++ b/tests/Timezone/UserBasedTimezoneDetectorTest.php
@@ -48,12 +48,22 @@ final class UserBasedTimezoneDetectorTest extends TestCase
                 $this->timezone = $timezone;
             }
 
-            public function getPassword(): ?string
+            /**
+             * @todo: Remove this method when support for "symfony/security" < 6.0 is dropped.
+             *
+             * @return null
+             */
+            public function getPassword()
             {
                 return null;
             }
 
-            public function getSalt(): ?string
+            /**
+             * @todo: Remove this method when support for "symfony/security" < 6.0 is dropped.
+             *
+             * @return null
+             */
+            public function getSalt()
             {
                 return null;
             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
PHPStan detects that other values than `null` are not returned and suggests to update the return type accordingly, but the `null` return type is supported since PHP 8.2 and we are currently supporting PHP 8.0:
>... never returns null so it can be removed from the return type.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

See: https://github.com/sonata-project/SonataIntlBundle/actions/runs/7240749104/job/19724081508?pr=602#step:5:11.


