### PR TITLE
Remove deprecated usages of `spaceless` twig filter

### DIFF
--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -9,15 +9,13 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {% set pattern = field_description.options.pattern|default(null) %}
-        {% set locale = field_description.options.locale|default(null) %}
-        {% set timezone = field_description.options.timezone|default(null) %}
-        {% set dateType = field_description.options.dateType|default(null) %}
+{%- if value is empty -%}
+    &nbsp;
+{%- else -%}
+    {% set pattern = field_description.options.pattern|default(null) %}
+    {% set locale = field_description.options.locale|default(null) %}
+    {% set timezone = field_description.options.timezone|default(null) %}
+    {% set dateType = field_description.options.dateType|default(null) %}
 
-        <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">{{ value | sonata_format_date(pattern, locale, timezone, dateType) }}</time>
-    {%- endif -%}
-{% endapply -%}
+    <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">{{ value | sonata_format_date(pattern, locale, timezone, dateType) }}</time>
+{%- endif -%}

--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -9,16 +9,14 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
-    {%- if value is empty -%}
-        &nbsp;
-    {%- else -%}
-        {% set pattern = field_description.options.pattern|default(null) %}
-        {% set locale = field_description.options.locale|default(null) %}
-        {% set timezone = field_description.options.timezone|default(null) %}
-        {% set dateType = field_description.options.dateType|default(null) %}
-        {% set timeType = field_description.options.timeType|default(null) %}
+{%- if value is empty -%}
+    &nbsp;
+{%- else -%}
+    {% set pattern = field_description.options.pattern|default(null) %}
+    {% set locale = field_description.options.locale|default(null) %}
+    {% set timezone = field_description.options.timezone|default(null) %}
+    {% set dateType = field_description.options.dateType|default(null) %}
+    {% set timeType = field_description.options.timeType|default(null) %}
 
-        <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">{{ value | sonata_format_datetime(pattern, locale, timezone, dateType, timeType) }}</time>
-    {%- endif -%}
-{% endapply -%}
+    <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">{{ value | sonata_format_datetime(pattern, locale, timezone, dateType, timeType) }}</time>
+{%- endif -%}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataIntlBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataIntlBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Deprecated usages of `spaceless` twig filter
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
