### PR TITLE
Fix `format_datetime` twig filter deprecation message

### DIFF
--- a/src/Twig/Extension/DateTimeExtension.php
+++ b/src/Twig/Extension/DateTimeExtension.php
@@ -126,8 +126,8 @@ class DateTimeExtension extends AbstractExtension
     public function formatDatetime($time, $pattern = null, $locale = null, $timezone = null, $dateType = null, $timeType = null)
     {
         @trigger_error(
-            'The format_date_time filter is deprecated since 2.12 and will be removed on 3.0. '.
-            'Use sonata_format_date_time instead.',
+            'The format_datetime filter is deprecated since 2.12 and will be removed on 3.0. '.
+            'Use sonata_format_datetime instead.',
             \E_USER_DEPRECATED
         );
 


### PR DESCRIPTION
## Subject
The twig filter name in the deprecation message have a typo.

I am targeting this branch, because the typo is in 2.x and this message is removed in 3.0.

## Changelog

```markdown
### Fixed
`format_datetime` twig filter deprecation message
```
